### PR TITLE
Add support for hash field expiration commands

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,13 @@ jobs:
               db-org: valkey-io,
               db-name: valkey,
               db-version: 8.0.1
-            },            
+            },
+            {
+              rust: stable,
+              db-org: redis,
+              db-name: redis,
+              db-version: 8.0-m04
+            },
 
             # Different rust cases
             {

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
               rust: stable,
               db-org: redis,
               db-name: redis,
-              db-version: 8.0-m04
+              db-version: 8.0-rc1
             },
 
             # Different rust cases

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -196,6 +196,7 @@ once_cell = "1"
 anyhow = "1"
 redis-test = { path = "../redis-test" }
 rstest = "0.24"
+rand = "0.9"
 
 [[test]]
 name = "test_async"

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -58,9 +58,7 @@ pub(crate) fn is_readonly_cmd(cmd: &[u8]) -> bool {
             | b"HEXISTS"
             | b"HEXPIRETIME"
             | b"HGET"
-            | b"HGETEX"
             | b"HGETALL"
-            | b"HGETDEL"
             | b"HKEYS"
             | b"HLEN"
             | b"HMGET"
@@ -68,7 +66,6 @@ pub(crate) fn is_readonly_cmd(cmd: &[u8]) -> bool {
             | b"HPTTL"
             | b"HPEXPIRETIME"
             | b"HSCAN"
-            | b"HSETEX"
             | b"HSTRLEN"
             | b"HTTL"
             | b"HVALS"
@@ -2720,12 +2717,8 @@ impl ToRedisArgs for HashFieldExpirationOptions {
     {
         if let Some(ref existence_check) = self.existence_check {
             match existence_check {
-                FieldExistenceCheck::FNX => {
-                    out.write_arg(b"FNX");
-                }
-                FieldExistenceCheck::FXX => {
-                    out.write_arg(b"FXX");
-                }
+                FieldExistenceCheck::FNX => out.write_arg(b"FNX"),
+                FieldExistenceCheck::FXX => out.write_arg(b"FXX"),
             }
         }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -543,8 +543,8 @@ pub use crate::client::Client;
 pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
-    Commands, ControlFlow, Direction, FlushAllOptions, FlushDbOptions, LposOptions, PubSubCommands,
-    ScanOptions, SetOptions,
+    Commands, ControlFlow, Direction, FlushAllOptions, FlushDbOptions, HashFieldExpirationOptions,
+    LposOptions, PubSubCommands, ScanOptions, SetOptions,
 };
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
@@ -577,6 +577,7 @@ pub use crate::types::{
     Expiry,
     SetExpiry,
     ExistenceCheck,
+    FieldExistenceCheck,
     ExpireOption,
     Role,
     ReplicaInfo,

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -68,6 +68,15 @@ pub enum ExistenceCheck {
     XX,
 }
 
+/// Helper enum that is used to define field existence checks
+#[derive(Clone, Copy)]
+pub enum FieldExistenceCheck {
+    /// FNX -- Only set the fields if all do not already exist.
+    FNX,
+    /// FXX -- Only set the fields if all already exist.
+    FXX,
+}
+
 /// Helper enum that is used in some situations to describe
 /// the behavior of arguments in a numeric context.
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -5,11 +5,15 @@ mod support;
 #[cfg(test)]
 mod basic {
     use assert_approx_eq::assert_approx_eq;
-    use redis::{cmd, Client, ProtocolVersion, PushInfo, RedisConnectionInfo, Role, ScanOptions};
+    use rand::distr::Alphanumeric;
+    use rand::{rng, Rng};
+    use redis::{
+        cmd, Client, Connection, ProtocolVersion, PushInfo, RedisConnectionInfo, Role, ScanOptions,
+    };
     use redis::{
         Commands, ConnectionInfo, ConnectionLike, ControlFlow, ErrorKind, ExistenceCheck,
-        ExpireOption, Expiry, PubSubCommands, PushKind, RedisResult, SetExpiry, SetOptions,
-        ToRedisArgs, Value,
+        ExpireOption, Expiry, FieldExistenceCheck, HashFieldExpirationOptions, PubSubCommands,
+        PushKind, RedisResult, SetExpiry, SetOptions, ToRedisArgs, Value,
     };
     use redis_test::utils::get_listener_on_free_port;
     use std::collections::{BTreeMap, BTreeSet};
@@ -20,6 +24,37 @@ mod basic {
     use std::vec;
 
     use crate::{assert_args, support::*};
+
+    const HASH_FIELD_EXPIRATION_MINIMUM_REQUIRED_VERSION: (u16, u16, u16) = (7, 9, 0);
+    const HASH_KEY: &str = "testing_hash";
+    const HASH_FIELDS_AND_VALUES: [(&str, u8); 5] =
+        [("f1", 1), ("f2", 2), ("f3", 4), ("f4", 8), ("f5", 16)];
+    const FIELD_EXISTS_WITHOUT_TTL: i8 = -1;
+
+    /// Generates a unique hash key that does not already exist.
+    fn generate_random_testing_hash_key(con: &mut Connection) -> String {
+        const TEST_HASH_KEY_BASE: &str = "testing_hash";
+        const TEST_HASH_KEY_RANDOM_LENGTH: usize = 7;
+
+        loop {
+            let generated_hash_key = format!(
+                "{}_{}",
+                TEST_HASH_KEY_BASE,
+                rng()
+                    .sample_iter(&Alphanumeric)
+                    .take(TEST_HASH_KEY_RANDOM_LENGTH)
+                    .map(char::from)
+                    .collect::<String>()
+            );
+
+            let hash_exists: bool = con.exists(&generated_hash_key).unwrap();
+
+            if !hash_exists {
+                println!("Generated random testing hash key: {}", &generated_hash_key);
+                return generated_hash_key;
+            }
+        }
+    }
 
     #[test]
     fn test_parse_redis_url() {
@@ -402,6 +437,637 @@ mod basic {
         assert_eq!(ttls, vec![-1, -1]);
 
         assert_eq!(con.unlink(&["foo"]), Ok(1));
+    }
+
+    fn run_test_if_version_supported<F>(minimum_required_version: &(u16, u16, u16), test_fn: F)
+    where
+        F: FnOnce(TestContext),
+    {
+        let ctx = TestContext::new();
+        let redis_version = ctx.get_version();
+
+        if redis_version < *minimum_required_version {
+            println!("Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
+                    redis_version, minimum_required_version);
+            return;
+        }
+
+        test_fn(ctx); // Execute the test logic
+    }
+
+    /// Verify that the hash contains exactly the specified fields with their corresponding values.
+    fn verify_exact_hash_fields_and_values(
+        con: &mut Connection,
+        hash_key: &str,
+        hash_fields_and_values: &[(&str, u8)],
+    ) {
+        let hash_fields: HashMap<String, u8> = con.hgetall(hash_key).unwrap();
+        assert_eq!(hash_fields.len(), hash_fields_and_values.len());
+
+        for (field, value) in hash_fields_and_values {
+            assert_eq!(hash_fields.get(*field), Some(value));
+        }
+    }
+
+    #[inline(always)]
+    fn verify_fields_absence_from_hash(
+        hash_fields: &HashMap<String, String>,
+        hash_fields_to_check: &[&str],
+    ) {
+        hash_fields_to_check.iter().for_each(|key| {
+            assert!(!hash_fields.contains_key(*key));
+        });
+    }
+
+    /// The test validates the following scenarios for the HGETDEL command:
+    ///
+    /// 1. It successfully deletes a single field from a given existing hash.
+    /// 2. Attempting to delete a non-existing field from a given existing hash results in a NIL response.
+    /// 3. It successfully deletes multiple fields from a given existing hash.
+    /// 4. When used on a hash with only one field, it deletes the entire hash.
+    /// 5. Attempting to delete a field from a non-existing hash results in a NIL response.
+    #[test]
+    fn test_hget_del() {
+        run_test_if_version_supported(&HASH_FIELD_EXPIRATION_MINIMUM_REQUIRED_VERSION, |ctx| {
+            let mut con = ctx.connection();
+            // Create a hash with multiple fields and values that will be used for testing
+            assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
+
+            // Delete the first field
+            let deleted_fields: Vec<u8> =
+                con.hget_del(HASH_KEY, HASH_FIELDS_AND_VALUES[0].0).unwrap();
+            assert_eq!(deleted_fields.len(), 1);
+            assert_eq!(deleted_fields[0], HASH_FIELDS_AND_VALUES[0].1);
+
+            let mut removed_fields = Vec::from([HASH_FIELDS_AND_VALUES[0].0]);
+
+            // Verify that the field has been deleted
+            let remaining_hash_fields: HashMap<String, String> = con.hgetall(HASH_KEY).unwrap();
+            assert_eq!(
+                remaining_hash_fields.len(),
+                HASH_FIELDS_AND_VALUES.len() - removed_fields.len()
+            );
+            verify_fields_absence_from_hash(&remaining_hash_fields, &removed_fields);
+
+            // Verify that a non-existing field returns NIL by attempting to delete the same field again
+            let deleted_fields: redis::RedisResult<Vec<u8>> =
+                con.hget_del(HASH_KEY, &removed_fields);
+            assert!(
+                matches!(deleted_fields, Err(err) if err.kind() == redis::ErrorKind::TypeError)
+            );
+
+            // Prepare additional fields for deletion
+            let fields_to_delete = [
+                HASH_FIELDS_AND_VALUES[1].0,
+                HASH_FIELDS_AND_VALUES[2].0,
+                HASH_FIELDS_AND_VALUES[3].0,
+            ];
+
+            // Delete the additional fields
+            let deleted_fields: Vec<u8> = con.hget_del(HASH_KEY, &fields_to_delete).unwrap();
+            assert_eq!(deleted_fields.len(), fields_to_delete.len());
+            assert_eq!(deleted_fields[0], HASH_FIELDS_AND_VALUES[1].1);
+            assert_eq!(deleted_fields[1], HASH_FIELDS_AND_VALUES[2].1);
+            assert_eq!(deleted_fields[2], HASH_FIELDS_AND_VALUES[3].1);
+
+            removed_fields.extend_from_slice(&fields_to_delete);
+
+            // Verify that all of the fields have been deleted
+            let remaining_hash_fields: HashMap<String, String> = con.hgetall(HASH_KEY).unwrap();
+            assert_eq!(
+                remaining_hash_fields.len(),
+                HASH_FIELDS_AND_VALUES.len() - removed_fields.len()
+            );
+            verify_fields_absence_from_hash(&remaining_hash_fields, &removed_fields);
+
+            // Verify that removing the last field deletes the hash
+            let deleted_fields: Vec<u8> =
+                con.hget_del(HASH_KEY, HASH_FIELDS_AND_VALUES[4].0).unwrap();
+            assert_eq!(deleted_fields.len(), 1);
+            assert_eq!(deleted_fields[0], HASH_FIELDS_AND_VALUES[4].1);
+            let hash_exists: bool = con.exists(HASH_KEY).unwrap();
+            assert!(!hash_exists);
+
+            // Verify that HGETDEL on a non-existing hash returns NIL
+            let deleted_fields: redis::RedisResult<Vec<u8>> =
+                con.hget_del(HASH_KEY, HASH_FIELDS_AND_VALUES[4].0);
+            assert!(
+                matches!(deleted_fields, Err(err) if err.kind() == redis::ErrorKind::TypeError)
+            );
+        });
+    }
+
+    /// The test validates the following scenarios for the HGETEX command:
+    ///
+    /// 1. It successfully retrieves a single field from a given existing hash without setting its expiration.
+    /// 2. It successfully retrieves multiple fields from a given existing hash without setting their expiration.
+    /// 3. It successfully retrieves a single field from a given existing hash and sets its expiration to 1 second.
+    ///    It verifies that the field has been set to expire and that it is no longer present in the hash after it expires.
+    /// 4. Attempting to retrieve a non-existing field from a given existing hash returns in a NIL response.
+    /// 5. It successfully retrieves multiple fields from a given existing hash and sets their expiration to 1 second.
+    ///    It verifies that the fields have been set to expire and that they are no longer present in the hash after they expire.
+    /// 6. Attempting to retrieve a field from a non-existing hash returns in a NIL response.
+    #[test]
+    fn test_hget_ex() {
+        run_test_if_version_supported(&HASH_FIELD_EXPIRATION_MINIMUM_REQUIRED_VERSION, |ctx| {
+            let mut con = ctx.connection();
+            // Create a hash with multiple fields and values that will be used for testing
+            assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
+
+            // Retrieve a single field without setting its expiration
+            let hash_field_values: Vec<u8> = con
+                .hget_ex(HASH_KEY, HASH_FIELDS_AND_VALUES[0].0, Expiry::PERSIST)
+                .unwrap();
+            assert_eq!(hash_field_values.len(), 1);
+            assert_eq!(hash_field_values[0], HASH_FIELDS_AND_VALUES[0].1);
+            let hash_field_ttls: Vec<i8> = con.httl(HASH_KEY, HASH_FIELDS_AND_VALUES[0].0).unwrap();
+            assert_eq!(hash_field_ttls.len(), 1);
+            assert_eq!(hash_field_ttls[0], FIELD_EXISTS_WITHOUT_TTL);
+
+            // Retrieve multiple fields at once without setting their expiration
+            let fields_to_retrieve = [HASH_FIELDS_AND_VALUES[1].0, HASH_FIELDS_AND_VALUES[2].0];
+
+            let hash_field_values: Vec<u8> = con
+                .hget_ex(HASH_KEY, &fields_to_retrieve, Expiry::PERSIST)
+                .unwrap();
+            assert_eq!(hash_field_values.len(), fields_to_retrieve.len());
+            assert_eq!(hash_field_values[0], HASH_FIELDS_AND_VALUES[1].1);
+            assert_eq!(hash_field_values[1], HASH_FIELDS_AND_VALUES[2].1);
+            let hash_field_ttls: Vec<i8> = con.httl(HASH_KEY, &fields_to_retrieve).unwrap();
+            assert_eq!(hash_field_ttls.len(), fields_to_retrieve.len());
+            assert_eq!(hash_field_ttls[0], FIELD_EXISTS_WITHOUT_TTL);
+            assert_eq!(hash_field_ttls[1], FIELD_EXISTS_WITHOUT_TTL);
+
+            // Retrieve a single field and set its expiration to 1 second
+            let hash_field_values: Vec<u8> = con
+                .hget_ex(HASH_KEY, HASH_FIELDS_AND_VALUES[0].0, Expiry::EX(1))
+                .unwrap();
+            assert_eq!(hash_field_values.len(), 1);
+            assert_eq!(hash_field_values[0], HASH_FIELDS_AND_VALUES[0].1);
+
+            // Verify that the all fields are still present in the hash
+            verify_exact_hash_fields_and_values(&mut con, HASH_KEY, &HASH_FIELDS_AND_VALUES);
+
+            // Verify that the field has been set to expire
+            let hash_field_ttls: Vec<i8> = con.httl(HASH_KEY, HASH_FIELDS_AND_VALUES[0].0).unwrap();
+            assert_eq!(hash_field_ttls.len(), 1);
+            assert_eq!(hash_field_ttls[0], 1);
+
+            // Wait for the field to expire
+            sleep(Duration::from_millis(1100));
+
+            let mut expired_fields = Vec::from([HASH_FIELDS_AND_VALUES[0].0]);
+
+            // Verify that the field has expired
+            let remaining_hash_fields: HashMap<String, String> = con.hgetall(HASH_KEY).unwrap();
+            assert_eq!(
+                remaining_hash_fields.len(),
+                HASH_FIELDS_AND_VALUES.len() - expired_fields.len()
+            );
+
+            verify_fields_absence_from_hash(&remaining_hash_fields, &expired_fields);
+
+            // Verify that a non-existing field returns NIL by attempting to retrieve it with HGETEX
+            let hash_field_values: redis::RedisResult<Vec<u8>> =
+                con.hget_ex(HASH_KEY, &expired_fields, Expiry::PERSIST);
+            assert!(
+                matches!(hash_field_values, Err(err) if err.kind() == redis::ErrorKind::TypeError)
+            );
+
+            // Retrieve multiple fields and set their expiration to 1 second
+            let fields_to_expire = [
+                HASH_FIELDS_AND_VALUES[1].0,
+                HASH_FIELDS_AND_VALUES[2].0,
+                HASH_FIELDS_AND_VALUES[3].0,
+                HASH_FIELDS_AND_VALUES[4].0,
+            ];
+
+            let hash_field_values: Vec<u8> = con
+                .hget_ex(HASH_KEY, &fields_to_expire, Expiry::EX(1))
+                .unwrap();
+            assert_eq!(hash_field_values.len(), fields_to_expire.len());
+
+            for i in 0..fields_to_expire.len() {
+                assert_eq!(hash_field_values[i], HASH_FIELDS_AND_VALUES[i + 1].1);
+            }
+
+            // Verify that all fields, except the first one, which has already expired, are still present in the hash
+            verify_exact_hash_fields_and_values(&mut con, HASH_KEY, &HASH_FIELDS_AND_VALUES[1..]);
+
+            // Verify that the fields have been set to expire
+            let hash_field_ttls: Vec<i8> = con.httl(HASH_KEY, &fields_to_expire).unwrap();
+            assert_eq!(hash_field_ttls.len(), fields_to_expire.len());
+            assert_eq!(hash_field_ttls, vec![1; fields_to_expire.len()]);
+
+            // Wait for the fields to expire
+            sleep(Duration::from_millis(1100));
+
+            expired_fields.extend_from_slice(&fields_to_expire);
+
+            // Verify that the fields have expired
+            let remaining_hash_fields: HashMap<String, String> = con.hgetall(HASH_KEY).unwrap();
+            assert_eq!(
+                remaining_hash_fields.len(),
+                HASH_FIELDS_AND_VALUES.len() - expired_fields.len()
+            );
+            verify_fields_absence_from_hash(&remaining_hash_fields, &expired_fields);
+
+            // Verify that HGETEX on a non-existing hash returns NIL
+            let hash_exists: bool = con.exists(HASH_KEY).unwrap();
+            assert!(!hash_exists);
+            let hash_field_values: redis::RedisResult<Vec<u8>> =
+                con.hget_ex(HASH_KEY, &expired_fields, Expiry::PERSIST);
+            assert!(
+                matches!(hash_field_values, Err(err) if err.kind() == redis::ErrorKind::TypeError)
+            );
+        });
+    }
+
+    /// The test validates the various expiration options for hash fields using the HGETEX command.
+    ///
+    /// It tests setting expiration using the EX, PX, EXAT, and PXAT options,
+    /// as well as removing an existing expiration using the PERSIST option.
+    #[test]
+    fn test_hget_ex_field_expiration_options() {
+        run_test_if_version_supported(&HASH_FIELD_EXPIRATION_MINIMUM_REQUIRED_VERSION, |ctx| {
+            let mut con = ctx.connection();
+            // Create a hash with multiple fields and values that will be used for testing
+            assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
+
+            // Verify that initially all fields are present in the hash
+            verify_exact_hash_fields_and_values(&mut con, HASH_KEY, &HASH_FIELDS_AND_VALUES);
+
+            // Set the fields to expire in 1 second using different expiration options
+            let getex_response: Vec<u8> = con
+                .hget_ex(HASH_KEY, HASH_FIELDS_AND_VALUES[0].0, Expiry::EX(1))
+                .unwrap();
+            assert_eq!(getex_response[0], HASH_FIELDS_AND_VALUES[0].1);
+            let getex_response: Vec<u8> = con
+                .hget_ex(HASH_KEY, HASH_FIELDS_AND_VALUES[1].0, Expiry::PX(1000))
+                .unwrap();
+            assert_eq!(getex_response[0], HASH_FIELDS_AND_VALUES[1].1);
+            let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+            let getex_response: Vec<u8> = con
+                .hget_ex(
+                    HASH_KEY,
+                    HASH_FIELDS_AND_VALUES[2].0,
+                    Expiry::EXAT(current_timestamp.as_secs() + 1),
+                )
+                .unwrap();
+            assert_eq!(getex_response[0], HASH_FIELDS_AND_VALUES[2].1);
+            let getex_response: Vec<u8> = con
+                .hget_ex(
+                    HASH_KEY,
+                    HASH_FIELDS_AND_VALUES[3].0,
+                    Expiry::PXAT(current_timestamp.as_millis() as u64 + 1000),
+                )
+                .unwrap();
+            assert_eq!(getex_response[0], HASH_FIELDS_AND_VALUES[3].1);
+            let getex_response: Vec<u8> = con
+                .hget_ex(HASH_KEY, HASH_FIELDS_AND_VALUES[4].0, Expiry::EX(1))
+                .unwrap();
+            assert_eq!(getex_response[0], HASH_FIELDS_AND_VALUES[4].1);
+            // Remove the expiration from the last field
+            let getex_response: Vec<u8> = con
+                .hget_ex(HASH_KEY, HASH_FIELDS_AND_VALUES[4].0, Expiry::PERSIST)
+                .unwrap();
+            assert_eq!(getex_response[0], HASH_FIELDS_AND_VALUES[4].1);
+
+            // Wait for the fields to expire and verify that only the last field remains in the hash
+            sleep(Duration::from_millis(1100));
+            verify_exact_hash_fields_and_values(&mut con, HASH_KEY, &[HASH_FIELDS_AND_VALUES[4]]);
+
+            // Remove the hash
+            assert_eq!(con.del(HASH_KEY), Ok(1));
+        });
+    }
+
+    ///  The test validates the following scenarios for the HSETEX command:
+    ///
+    ///  Tests the behavior of HSETEX with different field existence checks (FNX and FXX):
+    ///     1. (FNX) successfully sets fields in a hash that does not exist and creates the hash.
+    ///     2. (FNX) fails to set fields in a hash that already contains one or more of the fields.
+    ///     3. (FXX) fails to set fields in a hash that does not have one or more of the fields.
+    ///
+    ///  Tests the behavior of HSETEX with and without expiration:
+    ///
+    ///     Note: All of the following tests, use FXX and operate on existing fields.
+    ///
+    ///     4. It successfully sets a single field without setting its expiration
+    ///        and verifies that the value has been modified, but no expiration is set.
+    ///     5. It successfully sets multiple fields without setting their expiration
+    ///        and verifies that their values have been modified, but no expiration is set.
+    ///     6. It successfully sets a single field with an expiration
+    ///        and verifies that the value has been modified and the field is set to expire.
+    ///     7. It successfully sets all fields with an expiration
+    ///        and verifies that their values have been modified and the fields are set to expire.
+    #[test]
+    fn test_hset_ex() {
+        run_test_if_version_supported(&HASH_FIELD_EXPIRATION_MINIMUM_REQUIRED_VERSION, |ctx| {
+            let mut con = ctx.connection();
+
+            let generated_hash_key = generate_random_testing_hash_key(&mut con);
+
+            let hfe_options =
+                HashFieldExpirationOptions::default().set_existence_check(FieldExistenceCheck::FNX);
+
+            // Verify that HSETEX with FNX on a hash that does not exist succeeds
+            // and creates the hash with the specified fields and values
+            let fields_set_successfully: bool = con
+                .hset_ex(&generated_hash_key, &hfe_options, &HASH_FIELDS_AND_VALUES)
+                .unwrap();
+            assert!(fields_set_successfully);
+
+            // Verify that the hash has been created with the expected fields and values
+            verify_exact_hash_fields_and_values(
+                &mut con,
+                &generated_hash_key,
+                &HASH_FIELDS_AND_VALUES,
+            );
+
+            let fields_and_values_for_update = [HASH_FIELDS_AND_VALUES[0], ("NonExistingField", 1)];
+
+            // Executing HSETEX with FNX on a hash that already contains a field should fail
+            let field_set_successfully: bool = con
+                .hset_ex(
+                    &generated_hash_key,
+                    &hfe_options,
+                    &fields_and_values_for_update,
+                )
+                .unwrap();
+            assert!(!field_set_successfully);
+
+            // Verify that the hash consists of its original fields
+            verify_exact_hash_fields_and_values(
+                &mut con,
+                &generated_hash_key,
+                &HASH_FIELDS_AND_VALUES,
+            );
+
+            let hfe_options = hfe_options.set_existence_check(FieldExistenceCheck::FXX);
+
+            // Executing HSETEX with FXX on a hash that does not have one or more of the fields should fail
+            let field_set_successfully: bool = con
+                .hset_ex(
+                    &generated_hash_key,
+                    &hfe_options,
+                    &fields_and_values_for_update,
+                )
+                .unwrap();
+            assert!(!field_set_successfully);
+
+            // Verify that the hash consists of its original fields
+            verify_exact_hash_fields_and_values(
+                &mut con,
+                &generated_hash_key,
+                &HASH_FIELDS_AND_VALUES,
+            );
+
+            // Set a single field without setting its expiration
+            // Use the HSETEX command to double the value of the first field
+            let initial_fields = HASH_FIELDS_AND_VALUES.map(|(key, _)| key);
+
+            let first_field_with_doubled_value =
+                [(HASH_FIELDS_AND_VALUES[0].0, HASH_FIELDS_AND_VALUES[0].1 * 2)];
+            let field_set_successfully: bool = con
+                .hset_ex(
+                    &generated_hash_key,
+                    &hfe_options,
+                    &first_field_with_doubled_value,
+                )
+                .unwrap();
+            assert!(field_set_successfully);
+
+            // Verify that the field's value has been set to the new value
+            let hash_fields: HashMap<String, u8> = con.hgetall(&generated_hash_key).unwrap();
+            assert_eq!(hash_fields.len(), initial_fields.len());
+            assert_eq!(
+                hash_fields[first_field_with_doubled_value[0].0],
+                first_field_with_doubled_value[0].1
+            );
+
+            // Verify that the field is not set to expire
+            let hash_field_ttls: Vec<i8> = con
+                .httl(&generated_hash_key, first_field_with_doubled_value[0].0)
+                .unwrap();
+            assert_eq!(hash_field_ttls.len(), first_field_with_doubled_value.len());
+            assert_eq!(hash_field_ttls[0], FIELD_EXISTS_WITHOUT_TTL);
+
+            // Use the HSETEX command to double the original values of all fields
+            let fields_with_doubled_values: Vec<(&str, u8)> = HASH_FIELDS_AND_VALUES
+                .iter()
+                .map(|(field, value)| (*field, value * 2))
+                .collect();
+            let fields_set_successfully: bool = con
+                .hset_ex(
+                    &generated_hash_key,
+                    &hfe_options,
+                    &fields_with_doubled_values,
+                )
+                .unwrap();
+            assert!(fields_set_successfully);
+
+            // Verify that the values of the fields have been set to the new values.
+            verify_exact_hash_fields_and_values(
+                &mut con,
+                &generated_hash_key,
+                &fields_with_doubled_values,
+            );
+
+            // Verify that the fields are not set to expire
+            let hash_field_ttls: Vec<i8> = con.httl(&generated_hash_key, &initial_fields).unwrap();
+            assert_eq!(hash_field_ttls.len(), fields_with_doubled_values.len());
+            assert_eq!(
+                hash_field_ttls,
+                vec![FIELD_EXISTS_WITHOUT_TTL; fields_with_doubled_values.len()]
+            );
+
+            // Set a single field and set its expiration to 10 seconds
+            let hfe_options = hfe_options.set_expiration(SetExpiry::EX(10));
+
+            // Use the HSETEX command to triple the original value of the first field
+            // and set its expiration to 10 seconds
+            let first_field_with_tripled_value =
+                [(HASH_FIELDS_AND_VALUES[0].0, HASH_FIELDS_AND_VALUES[0].1 * 3)];
+            let field_set_successfully: bool = con
+                .hset_ex(
+                    &generated_hash_key,
+                    &hfe_options,
+                    &first_field_with_tripled_value,
+                )
+                .unwrap();
+            assert!(field_set_successfully);
+
+            // Verify that the field's value has been set to the new value
+            let hash_fields: HashMap<String, u8> = con.hgetall(&generated_hash_key).unwrap();
+            assert_eq!(hash_fields.len(), initial_fields.len());
+            assert_eq!(
+                hash_fields[first_field_with_tripled_value[0].0],
+                first_field_with_tripled_value[0].1
+            );
+
+            // Verify that the field was set to expire
+            let hash_field_ttls: Vec<i8> = con
+                .httl(&generated_hash_key, first_field_with_tripled_value[0].0)
+                .unwrap();
+            assert_eq!(hash_field_ttls.len(), first_field_with_tripled_value.len());
+            assert_eq!(hash_field_ttls[0], 10);
+
+            let hfe_options = hfe_options.set_expiration(SetExpiry::EX(1));
+            // Use the HSETEX command to triple the values of all initial fields
+            // and set their expiration to 1 second
+            let fields_with_tripled_values: Vec<(&str, u8)> = HASH_FIELDS_AND_VALUES
+                .iter()
+                .map(|(field, value)| (*field, value * 3))
+                .collect();
+            let fields_set_successfully: bool = con
+                .hset_ex(
+                    &generated_hash_key,
+                    &hfe_options,
+                    &fields_with_tripled_values,
+                )
+                .unwrap();
+            assert!(fields_set_successfully);
+
+            // Verify that the fields' values have been set to the new values
+            verify_exact_hash_fields_and_values(
+                &mut con,
+                &generated_hash_key,
+                &fields_with_tripled_values,
+            );
+
+            // Verify that the fields were set to expire
+            let hash_field_ttls: Vec<i8> = con.httl(&generated_hash_key, &initial_fields).unwrap();
+            assert_eq!(hash_field_ttls.len(), fields_with_tripled_values.len());
+            assert_eq!(hash_field_ttls, vec![1; fields_with_tripled_values.len()]);
+
+            // Wait for the fields to expire
+            sleep(Duration::from_millis(1100));
+
+            // Verify that the fields have expired
+            let remaining_hash_fields: HashMap<String, String> =
+                con.hgetall(&generated_hash_key).unwrap();
+            assert_eq!(
+                remaining_hash_fields.len(),
+                HASH_FIELDS_AND_VALUES.len() - initial_fields.len()
+            );
+            verify_fields_absence_from_hash(&remaining_hash_fields, &initial_fields);
+        });
+    }
+
+    /// The test validates the various expiration options for hash fields using the HSETEX command.
+    ///
+    /// It tests setting expiration using the EX, PX, EXAT, and PXAT options,
+    /// as well as keeping an existing expiration using the KEEPTTL option.
+    #[test]
+    fn test_hsetex_field_expiration_options() {
+        run_test_if_version_supported(&HASH_FIELD_EXPIRATION_MINIMUM_REQUIRED_VERSION, |ctx| {
+            let mut con = ctx.connection();
+            // Create a hash with multiple fields and values that will be used for testing
+            assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
+
+            // Verify that initially all fields are present in the hash
+            verify_exact_hash_fields_and_values(&mut con, HASH_KEY, &HASH_FIELDS_AND_VALUES);
+
+            // Set the fields to expire in 1 second using different expiration options
+            let hfe_options = HashFieldExpirationOptions::default()
+                .set_existence_check(FieldExistenceCheck::FXX)
+                .set_expiration(SetExpiry::EX(1));
+
+            let expiration_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[0]])
+                .unwrap();
+            assert!(expiration_set_successfully);
+
+            let hfe_options = hfe_options.set_expiration(SetExpiry::PX(1000));
+            let expiration_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[1]])
+                .unwrap();
+            assert!(expiration_set_successfully);
+
+            let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+
+            let hfe_options =
+                hfe_options.set_expiration(SetExpiry::EXAT(current_timestamp.as_secs() + 1));
+            let expiration_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[2]])
+                .unwrap();
+            assert!(expiration_set_successfully);
+
+            let hfe_options = hfe_options
+                .set_expiration(SetExpiry::PXAT(current_timestamp.as_millis() as u64 + 1000));
+            let expiration_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[3]])
+                .unwrap();
+            assert!(expiration_set_successfully);
+
+            let hfe_options = hfe_options.set_expiration(SetExpiry::EX(1));
+            let expiration_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[4]])
+                .unwrap();
+            assert!(expiration_set_successfully);
+
+            // Using KEEPTTL will preserve the 1 second set above
+            let hfe_options = hfe_options.set_expiration(SetExpiry::KEEPTTL);
+            let expiration_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[4]])
+                .unwrap();
+            assert!(expiration_set_successfully);
+
+            // Wait for the fields to expire and verify it
+            sleep(Duration::from_millis(1100));
+
+            // Verify that all fields have expired and the hash no longer exists
+            let hash_exists: bool = con.exists(HASH_KEY).unwrap();
+            assert!(!hash_exists);
+        });
+    }
+
+    #[test]
+    fn test_hsetex_can_update_the_expiration_of_a_field_that_has_already_been_set_to_expire() {
+        run_test_if_version_supported(&HASH_FIELD_EXPIRATION_MINIMUM_REQUIRED_VERSION, |ctx| {
+            let mut con = ctx.connection();
+            // Create a hash with multiple fields and values that will be used for testing
+            assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
+
+            let hfe_options = HashFieldExpirationOptions::default()
+                .set_existence_check(FieldExistenceCheck::FXX)
+                .set_expiration(SetExpiry::EX(1));
+
+            // Use the HSETEX command to set the first field to expire in 1 second
+            let field_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[0]])
+                .unwrap();
+            assert!(field_set_successfully);
+
+            // Use the HSETEX command again to set the timeout to 2 seconds
+            let hfe_options = hfe_options.set_expiration(SetExpiry::EX(2));
+            let field_set_successfully: bool = con
+                .hset_ex(HASH_KEY, &hfe_options, &[HASH_FIELDS_AND_VALUES[0]])
+                .unwrap();
+            assert!(field_set_successfully);
+            // Verify that all of the fields still have their initial values
+            verify_exact_hash_fields_and_values(&mut con, HASH_KEY, &HASH_FIELDS_AND_VALUES);
+
+            // Verify that the field was set to expire
+            let hash_field_ttls: Vec<i8> = con.httl(HASH_KEY, HASH_FIELDS_AND_VALUES[0].0).unwrap();
+            assert_eq!(hash_field_ttls.len(), 1);
+            assert_eq!(hash_field_ttls[0], 2);
+
+            // Wait for the field to expire
+            sleep(Duration::from_millis(2100));
+
+            // Verify that the field has expired
+            let remaining_hash_fields: HashMap<String, String> = con.hgetall(HASH_KEY).unwrap();
+            assert_eq!(
+                remaining_hash_fields.len(),
+                HASH_FIELDS_AND_VALUES.len() - 1
+            );
+            verify_fields_absence_from_hash(&remaining_hash_fields, &[HASH_FIELDS_AND_VALUES[0].0]);
+
+            // Remove the hash
+            assert_eq!(con.del(HASH_KEY), Ok(1));
+        });
     }
 
     // Requires redis-server >= 4.0.0.


### PR DESCRIPTION
# Hash field expiration commands

This Pull Request introduces new commands for interacting with the fields in a Redis hash data structure. 
The following commands have been added:

- **`HGETDEL`** - Retrieves and deletes the values of one or more fields from a hash stored at the specified key.
- **`HGETEX`** - Retrieves the values of one or more fields from a hash and optionally sets expiration on those fields.
- **`HSETEX`** - Sets the value of one or more fields of a given hash key, and optionally set their expiration.

These commands enhance the flexibility and control over managing hash data in Redis, allowing for more sophisticated field operations and expiration management.

## Command Specifications
This section provides detailed information on the new commands, including their descriptions, syntax, and expected replies.

### HGETDEL
**Description**:
Retrieves and deletes the values of one or more fields from a hash stored at the specified key.

**Syntax**:
**HGETDEL** _key_ **FIELDS** _numfields field_ [_field_ ...]

**Reply**:
Array reply: A list containing the value associated with each field. If a field does not exist, `nil` is returned in its place.

### HGETEX
**Description**:
Retrieves the values of one or more fields from a hash and optionally sets expiration on those fields.

**Syntax**:
**HGETEX** _key_  [**EX** _seconds_ | **PX** _milliseconds_ | **EXAT** _unix-time-seconds_ | **PXAT** _unix-time-milliseconds_ | **PERSIST**] **FIELDS** _numfields field_ [_field_ ...]

**Options**:

- Expiration options:
**EX** _seconds_ -- Set expiration time in seconds.
**PX** _milliseconds_ -- Set expiration time in milliseconds.
**EXAT** _timestamp-seconds_ -- Set absolute Unix expiration time (seconds).
**PXAT** _timestamp-milliseconds_ -- Set absolute Unix expiration time (milliseconds).
**PERSIST** -- Remove any existing expiration from the specified fields.

**Reply**:
Array reply: A list containing the value associated with each field. If a field does not exist, `nil` is returned in its place.

### HSETEX
**Description**:
Sets the value of one or more fields of a given hash key, and optionally set their expiration.

**Syntax**:
**HSETEX** _key_ [**FNX** | **FXX**] [**EX** _seconds_ | **PX** _milliseconds_ | **EXAT** _unix-time-seconds_ | **PXAT** _unix-time-milliseconds_ | **KEEPTTL**] **FIELDS** _numfields field value_ [_field value_ ...]

**Options**:

- Field existence options:
**FNX** -- Only set the fields if **none** of them already exist.
**FXX** -- Only set the fields if **all** of them already exist.

- Expiration options:
**EX** _seconds_ -- Set expiration time in seconds.
**PX** _milliseconds_ -- Set expiration time in milliseconds.
**EXAT** _timestamp-seconds_ -- Set absolute Unix expiration time (seconds).
**PXAT** _timestamp-milliseconds_ -- Set absolute Unix expiration time (milliseconds).
**KEEPTTL** -- Retain the time to live associated with the field(s).

**Reply**:
Integer reply:
`0` – No fields were set.
`1` – All fields were successfully set.

## Testing
Unit tests have been added for each command to ensure correct behavior.

- Tested scenarios for the **HGETDEL** command:

  - It successfully deletes **one or more fields** from a given **existing hash**.
  - Attempting to delete a **non-existing field** from a given **existing hash** results in a `NIL` response.
  - When used on a hash with **only one** field, it deletes the entire hash.
  - Attempting to delete a field from a **non-existing hash** results in a `NIL` response.

- Tested scenarios for the **HGETEX** command:

  - It successfully retrieves **one or more fields** from a given **existing hash without setting** their expiration.
  - It successfully retrieves **one or more fields** from a given **existing hash and sets** their expiration. It verifies that the expiration was applied correctly by checking that the field(s) are no longer present in the hash after the expiration time.
  - Attempting to retrieve a **non-existing field** from a given **existing hash** returns in a `NIL` response.
  - Attempting to retrieve a field from a **non-existing hash** returns in a `NIL` response.
  - It complies with the various expiration options for hash fields. This includes setting expiration with the  **EX**, **PX**, **EXAT**, and **PXAT** options, as well as removing an existing expiration using the **PERSIST** option.

- Tested scenarios for the **HSETEX** command:

  - It complies with the field existence checks (**FNX** and **FXX**)
  - It successfully sets **one or more fields without setting their expiration**, and verifies that the values **have been modified** while **no expiration** is applied.
  - It successfully sets **one or more fields with an expiration**, and verifies that the values have **been modified** and that the fields **are set** to expire.
  - It complies with the various expiration options for hash fields. This includes setting expiration with the  **EX**, **PX**, **EXAT**, and **PXAT** options, as well as keeping an existing expiration using the **KEEPTTL** option.
  - It is possible to update an existing expiration.