### PR TITLE
Add new operators to the BITOP command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,12 @@ jobs:
               db-name: redis,
               db-version: 8.0.2
             },
+            {
+              rust: stable,
+              db-org: redis,
+              db-name: redis,
+              db-version: 8.2-m01
+            },
 
             # Different rust cases
             {

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -448,6 +448,38 @@ implement_commands! {
         cmd("BITOP").arg("NOT").arg(dstkey).arg(srckey)
     }
 
+    /// DIFF(X, Y1, Y2, …) \
+    /// Perform a **set difference** to extract the members of X that are not members of any of Y1, Y2,…. \
+    /// Logical representation: X  ∧ ¬(Y1 ∨ Y2 ∨ …) \
+    /// [Redis Docs](https://redis.io/commands/BITOP)
+    fn bit_diff<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
+        cmd("BITOP").arg("DIFF").arg(dstkey).arg(srckeys)
+    }
+
+    /// DIFF1(X, Y1, Y2, …) (Relative complement difference) \
+    /// Perform a **relative complement set difference** to extract the members of one or more of Y1, Y2,… that are not members of X. \
+    /// Logical representation: ¬X  ∧ (Y1 ∨ Y2 ∨ …) \
+    /// [Redis Docs](https://redis.io/commands/BITOP)
+    fn bit_diff1<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
+        cmd("BITOP").arg("DIFF1").arg(dstkey).arg(srckeys)
+    }
+
+    /// ANDOR(X, Y1, Y2, …) \
+    /// Perform an **"intersection of union(s)"** operation to extract the members of X that are also members of one or more of Y1, Y2,…. \
+    /// Logical representation: X ∧ (Y1 ∨ Y2 ∨ …) \
+    /// [Redis Docs](https://redis.io/commands/BITOP)
+    fn bit_and_or<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
+        cmd("BITOP").arg("ANDOR").arg(dstkey).arg(srckeys)
+    }
+
+    /// ONE(X, Y1, Y2, …) \
+    /// Perform an **"exclusive membership"** operation to extract the members of exactly **one** of X, Y1, Y2, …. \
+    /// Logical representation: (X ∨ Y1 ∨ Y2 ∨ …) ∧ ¬((X ∧ Y1) ∨ (X ∧ Y2) ∨ (Y1 ∧ Y2) ∨ (Y1 ∧ Y3) ∨ …) \
+    /// [Redis Docs](https://redis.io/commands/BITOP)
+    fn bit_one<D: ToRedisArgs, S: ToRedisArgs>(dstkey: D, srckeys: S) -> (usize) {
+        cmd("BITOP").arg("ONE").arg(dstkey).arg(srckeys)
+    }
+
     /// Get the length of the value stored in a key.
     /// 0 if key does not exist.
     /// [Redis Docs](https://redis.io/commands/STRLEN)


### PR DESCRIPTION
# Add new **BITOP** operators

This Pull Request introduces support for additional logical bit operations using the `BITOP` command.

## New operators:

### ➖ `DIFF(X, Y1, Y2, …)` – **Set Difference**  
Extracts the members of `X` that are **not** in any of `Y1, Y2, …`.  
Logical form: `X ∧ ¬(Y1 ∨ Y2 ∨ …)`

### 🔄 `DIFF1(X, Y1, Y2, …)` – **Relative Complement Difference**  
Extracts the members in `Y1, Y2, …` that are **not** in `X`.  
Logical form: `¬X ∧ (Y1 ∨ Y2 ∨ …)`

### 🔗 `ANDOR(X, Y1, Y2, …)` – **Intersection of Unions**  
Extracts members of `X` that are also in **any** of `Y1, Y2, …`.  
Logical form: `X ∧ (Y1 ∨ Y2 ∨ …)`

### 🧩 `ONE(X, Y1, Y2, …)` – **Exclusive Membership**  
Extracts members that exist in **exactly one** of `X`, `Y1`, `Y2`, …  
Logical form:  `(X ∨ Y1 ∨ Y2 ∨ …) ∧ ¬((X ∧ Y1) ∨ (X ∧ Y2) ∨ (Y1 ∧ Y2) ∨ …)`

---

## 🧪 Tests

- ✅ Added a unit test covering both the original and newly added BITOP operators.

---

### 📚 References

- Official Redis Documentation: [BITOP](https://redis.io/commands/BITOP)
- Initial [Pull Request](https://github.com/redis/redis/pull/13898) that introduces the operations in Redis
