### PR TITLE
Stream idempotent producers (at-most-once guarantee)

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2082,7 +2082,7 @@ implement_commands! {
     /// Supports idempotent message production for preventing duplicate entries.
     ///
     /// [Idempotency Docs](https://redis.io/docs/latest/develop/data-types/streams/idempotency/)
-    /// See [`StreamAddOptions::idmp`] and [`StreamAddOptions::idmpauto`] for more details.
+    /// See [`streams::StreamAddOptions::idmp`] and [`streams::StreamAddOptions::idmpauto`] for more details.
     ///
     /// ```text
     /// XADD key [NOMKSTREAM] [KEEPREF | DELREF | ACKED] [IDMPAUTO pid | IDMP pid iid] [<MAXLEN|MINID> [~|=] threshold [LIMIT count]] <* | ID> field value [field value]  ...
@@ -2492,8 +2492,9 @@ implement_commands! {
     /// (first & last message `id`, length, number of groups, etc.)
     /// Take note of the StreamInfoStreamReply return type.
     ///
-    /// *It's possible this return value might not contain new fields
-    /// added by Redis in future versions.*
+    /// *It's possible this return value might not contain new fields added by Redis in future versions,
+    /// such as the idempotency fields introduced in Redis 8.6. For IDMP tracking statistics, use
+    /// [`xinfo_stream_with_idempotency`](Self::xinfo_stream_with_idempotency).*
     ///
     /// ```text
     /// XINFO STREAM <key>
@@ -2502,6 +2503,23 @@ implement_commands! {
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
     fn xinfo_stream<K: ToRedisArgs>(key: K) -> (streams::StreamInfoStreamReply) {
+        cmd("XINFO").arg("STREAM").arg(key).take()
+    }
+
+    // TODO: Remove this function when creating the next major release.
+    /// Returns stream info with idempotency tracking statistics (Redis 8.6+).
+    ///
+    /// This command returns [`StreamInfoStreamReplyWithIdempotency`](streams::StreamInfoStreamReplyWithIdempotency)
+    /// which composes [`StreamInfoStreamReply`](streams::StreamInfoStreamReply) (accessible via the `base` field)
+    /// and adds IDMP (Idempotent Message Processing) tracking fields.
+    ///
+    /// ```text
+    /// XINFO STREAM <key>
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/XINFO-STREAM)
+    #[cfg(feature = "streams")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    fn xinfo_stream_with_idempotency<K: ToRedisArgs>(key: K) -> (streams::StreamInfoStreamReplyWithIdempotency) {
         cmd("XINFO").arg("STREAM").arg(key).take()
     }
 
@@ -2835,6 +2853,43 @@ implement_commands! {
         options: &'a streams::StreamTrimOptions
     ) -> usize {
         cmd("XTRIM").arg(key).arg(options).take()
+    }
+
+    /// Configure idempotency parameters for a stream
+    ///
+    /// Sets the IDMP configuration parameters for a stream. This command configures
+    /// how long idempotent IDs are retained and the maximum number of idempotent IDs
+    /// tracked per producer.
+    ///
+    /// **Note:** Calling XCFGSET clears all existing producer IDMP maps for the stream.
+    ///
+    /// ```text
+    /// XCFGSET key [IDMP-DURATION idmp-duration] [IDMP-MAXSIZE idmp-maxsize]
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/XCFGSET)
+    ///
+    /// # Example
+    /// ```no_run
+    /// use redis::{Commands, streams::StreamConfigOptions};
+    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    ///
+    /// // Configure stream with 5 minute duration and max 1000 IDs per producer
+    /// // Valid ranges: IDMP-DURATION (1-86400), IDMP-MAXSIZE (1-10000)
+    /// let opts = StreamConfigOptions::with_duration(300)
+    ///     .unwrap()
+    ///     .maxsize(1000)
+    ///     .unwrap();
+    /// let result: String = con.xcfgset("key", &opts).unwrap();
+    /// assert_eq!(result, "OK");
+    /// ```
+    #[cfg(feature = "streams")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    fn xcfgset<K: ToRedisArgs>(
+        key: K,
+        options: &'a streams::StreamConfigOptions
+    ) -> String {
+        cmd("XCFGSET").arg(key).arg(options).take()
     }
 
     // script commands

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2876,9 +2876,9 @@ implement_commands! {
     ///
     /// // Configure stream with 5 minute duration and max 1000 IDs per producer
     /// // Valid ranges: IDMP-DURATION (1-86400), IDMP-MAXSIZE (1-10000)
-    /// let opts = StreamConfigOptions::with_duration(300)
+    /// let opts = StreamConfigOptions::with_idempotency_seconds(300)
     ///     .unwrap()
-    ///     .maxsize(1000)
+    ///     .idempotency_maxsize(1000)
     ///     .unwrap();
     /// let result: String = con.xcfgset("key", &opts).unwrap();
     /// assert_eq!(result, "OK");

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2079,8 +2079,13 @@ implement_commands! {
     /// map.insert("ij", "kl");
     /// ```
     ///
+    /// Supports idempotent message production for preventing duplicate entries.
+    ///
+    /// [Idempotency Docs](https://redis.io/docs/latest/develop/data-types/streams/idempotency/)
+    /// See [`StreamAddOptions::idmp`] and [`StreamAddOptions::idmpauto`] for more details.
+    ///
     /// ```text
-    /// XADD key [NOMKSTREAM] [<MAXLEN|MINID> [~|=] threshold [LIMIT count]] <* | ID> field value [field value] [KEEPREF | DELREF | ACKED] ...
+    /// XADD key [NOMKSTREAM] [KEEPREF | DELREF | ACKED] [IDMPAUTO pid | IDMP pid iid] [<MAXLEN|MINID> [~|=] threshold [LIMIT count]] <* | ID> field value [field value]  ...
     /// ```
     /// [Redis Docs](https://redis.io/commands/XADD)
     #[cfg(feature = "streams")]

--- a/redis/src/commands/streams.rs
+++ b/redis/src/commands/streams.rs
@@ -170,6 +170,52 @@ impl ToRedisArgs for StreamTrimOptions {
     }
 }
 
+/// Idempotency mode for stream message production
+///
+/// Supports idempotent message processing to prevent duplicate entries.
+/// See [Redis Streams Idempotency](https://redis.io/docs/latest/develop/data-types/streams/idempotency/)
+#[derive(Debug, Clone)]
+pub enum StreamIdempotencyMode {
+    /// Manual mode: Producer provides both producer ID (pid) and idempotent ID (iid)
+    ///
+    /// Example: `XADD key IDMP producer-1 iid-1 * field value`
+    Manual {
+        /// Producer ID - unique identifier for the message producer
+        producer_id: String,
+        /// Idempotent ID - unique identifier for this specific message
+        idempotent_id: String,
+    },
+    /// Automatic mode: Producer provides only producer ID (pid), Redis generates iid from message content
+    ///
+    /// Example: `XADD key IDMPAUTO producer-1 * field value`
+    Automatic {
+        /// Producer ID - unique identifier for the message producer
+        producer_id: String,
+    },
+}
+
+impl ToRedisArgs for StreamIdempotencyMode {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            StreamIdempotencyMode::Manual {
+                producer_id,
+                idempotent_id,
+            } => {
+                out.write_arg(b"IDMP");
+                out.write_arg(producer_id.as_bytes());
+                out.write_arg(idempotent_id.as_bytes());
+            }
+            StreamIdempotencyMode::Automatic { producer_id } => {
+                out.write_arg(b"IDMPAUTO");
+                out.write_arg(producer_id.as_bytes());
+            }
+        }
+    }
+}
+
 /// Builder options for [`xadd_options`] command
 ///
 /// [`xadd_options`]: ../trait.Commands.html#method.xadd_options
@@ -179,6 +225,7 @@ pub struct StreamAddOptions {
     nomkstream: bool,
     trim: Option<StreamTrimStrategy>,
     deletion_policy: Option<StreamDeletionPolicy>,
+    idempotency: Option<StreamIdempotencyMode>,
 }
 
 impl StreamAddOptions {
@@ -199,6 +246,66 @@ impl StreamAddOptions {
         self.deletion_policy = Some(deletion_policy);
         self
     }
+
+    /// Enable idempotent message production with manual mode (IDMP)
+    ///
+    /// Manual mode requires both producer ID and idempotent ID to be provided.
+    /// The producer ID uniquely identifies the message producer.
+    /// The idempotent ID uniquely identifies this specific message.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use redis::{Commands, streams::StreamAddOptions};
+    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    ///
+    /// let opts = StreamAddOptions::default()
+    ///     .idmp("producer-1", "iid-1");
+    /// let _: Option<String> = con.xadd_options(
+    ///     "key",
+    ///     "*",
+    ///     &[("field", "value")],
+    ///     &opts
+    /// ).unwrap();
+    /// ```
+    pub fn idmp(
+        mut self,
+        producer_id: impl Into<String>,
+        idempotent_id: impl Into<String>,
+    ) -> Self {
+        self.idempotency = Some(StreamIdempotencyMode::Manual {
+            producer_id: producer_id.into(),
+            idempotent_id: idempotent_id.into(),
+        });
+        self
+    }
+
+    /// Enable idempotent message production with automatic mode (IDMPAUTO)
+    ///
+    /// Automatic mode requires only a producer ID to be provided.
+    /// Redis automatically generates the idempotent ID based on the message content.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use redis::{Commands, streams::StreamAddOptions};
+    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    ///
+    /// let opts = StreamAddOptions::default()
+    ///     .idmpauto("producer-1");
+    /// let _: Option<String> = con.xadd_options(
+    ///     "key",
+    ///     "*",
+    ///     &[("field", "value")],
+    ///     &opts
+    /// ).unwrap();
+    /// ```
+    pub fn idmpauto(mut self, producer_id: impl Into<String>) -> Self {
+        self.idempotency = Some(StreamIdempotencyMode::Automatic {
+            producer_id: producer_id.into(),
+        });
+        self
+    }
 }
 
 impl ToRedisArgs for StreamAddOptions {
@@ -209,11 +316,14 @@ impl ToRedisArgs for StreamAddOptions {
         if self.nomkstream {
             out.write_arg(b"NOMKSTREAM");
         }
-        if let Some(strategy) = self.trim.as_ref() {
-            strategy.write_redis_args(out);
-        }
         if let Some(deletion_policy) = self.deletion_policy.as_ref() {
             deletion_policy.write_redis_args(out);
+        }
+        if let Some(idempotency) = self.idempotency.as_ref() {
+            idempotency.write_redis_args(out);
+        }
+        if let Some(strategy) = self.trim.as_ref() {
+            strategy.write_redis_args(out);
         }
     }
 }
@@ -1428,6 +1538,69 @@ mod tests {
                 .trim(StreamTrimStrategy::maxlen(StreamTrimmingMode::Exact, 10));
 
             assert_command_eq(options, b"NOMKSTREAM MAXLEN = 10");
+        }
+
+        #[test]
+        fn with_idmp_manual_mode() {
+            let options = StreamAddOptions::default().idmp("producer-1", "iid-1");
+
+            assert_command_eq(options, b"IDMP producer-1 iid-1");
+        }
+
+        #[test]
+        fn with_idmpauto_automatic_mode() {
+            let options = StreamAddOptions::default().idmpauto("producer-1");
+
+            assert_command_eq(options, b"IDMPAUTO producer-1");
+        }
+
+        #[test]
+        fn with_nomkstream_and_idmp() {
+            let options = StreamAddOptions::default()
+                .nomkstream()
+                .idmp("producer-1", "iid-1");
+
+            assert_command_eq(options, b"NOMKSTREAM IDMP producer-1 iid-1");
+        }
+
+        #[test]
+        fn with_trim_and_idmp() {
+            let options = StreamAddOptions::default()
+                .trim(StreamTrimStrategy::maxlen(StreamTrimmingMode::Exact, 100))
+                .idmp("producer-1", "iid-1");
+
+            assert_command_eq(options, b"IDMP producer-1 iid-1 MAXLEN = 100");
+        }
+
+        #[test]
+        fn with_all_options_and_idmp() {
+            let options = StreamAddOptions::default()
+                .nomkstream()
+                .trim(StreamTrimStrategy::maxlen(StreamTrimmingMode::Approx, 100))
+                .idmp("producer-1", "iid-1")
+                .set_deletion_policy(StreamDeletionPolicy::KeepRef);
+
+            assert_command_eq(
+                options,
+                b"NOMKSTREAM KEEPREF IDMP producer-1 iid-1 MAXLEN ~ 100",
+            );
+        }
+
+        #[test]
+        fn with_all_options_and_idmpauto() {
+            let options = StreamAddOptions::default()
+                .nomkstream()
+                .trim(StreamTrimStrategy::minid(
+                    StreamTrimmingMode::Exact,
+                    "123456-0",
+                ))
+                .idmpauto("producer-2")
+                .set_deletion_policy(StreamDeletionPolicy::DelRef);
+
+            assert_command_eq(
+                options,
+                b"NOMKSTREAM DELREF IDMPAUTO producer-2 MINID = 123456-0",
+            );
         }
     }
 }

--- a/redis/src/commands/streams.rs
+++ b/redis/src/commands/streams.rs
@@ -239,17 +239,17 @@ pub const IDMP_MAXSIZE_MAX: u16 = 10000;
 /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 /// # let mut con = client.get_connection().unwrap();
 ///
-/// // Create with duration, optionally add maxsize
-/// let opts1 = StreamConfigOptions::with_duration(300)
+/// // Create with idempotency duration in seconds, optionally add maxsize
+/// let opts1 = StreamConfigOptions::with_idempotency_seconds(300)
 ///     .unwrap()
-///     .maxsize(1000)
+///     .idempotency_maxsize(1000)
 ///     .unwrap();
 /// let _: String = con.xcfgset("key", &opts1).unwrap();
 ///
-/// // Or create with maxsize only and optionally add duration
-/// let opts2 = StreamConfigOptions::with_maxsize(500)
+/// // Or create with maxsize only and optionally add idempotency duration in seconds
+/// let opts2 = StreamConfigOptions::with_idempotency_maxsize(500)
 ///     .unwrap()
-///     .duration(300)
+///     .idempotency_seconds(300)
 ///     .unwrap();
 /// let _: String = con.xcfgset("key", &opts2).unwrap();
 /// ```
@@ -274,11 +274,10 @@ impl StreamConfigOptions {
     /// # Errors
     /// Returns an error if seconds is not in the valid range `1..=86400`
     /// (see [`IDMP_DURATION_MIN`] and [`IDMP_DURATION_MAX`])
-    pub fn with_duration(seconds: u32) -> Result<Self, String> {
+    pub fn with_idempotency_seconds(seconds: u32) -> Result<Self, String> {
         if !(IDMP_DURATION_MIN..=IDMP_DURATION_MAX).contains(&seconds) {
             return Err(format!(
-                "IDMP-DURATION must be between {} and {} seconds, got: {}",
-                IDMP_DURATION_MIN, IDMP_DURATION_MAX, seconds
+                "IDMP-DURATION must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX} seconds, got: {seconds}"
             ));
         }
         Ok(Self {
@@ -295,11 +294,10 @@ impl StreamConfigOptions {
     /// # Errors
     /// Returns an error if size is not in the valid range `1..=10000`
     /// (see [`IDMP_MAXSIZE_MIN`] and [`IDMP_MAXSIZE_MAX`])
-    pub fn with_maxsize(size: u16) -> Result<Self, String> {
+    pub fn with_idempotency_maxsize(size: u16) -> Result<Self, String> {
         if !(IDMP_MAXSIZE_MIN..=IDMP_MAXSIZE_MAX).contains(&size) {
             return Err(format!(
-                "IDMP-MAXSIZE must be between {} and {} entries, got: {}",
-                IDMP_MAXSIZE_MIN, IDMP_MAXSIZE_MAX, size
+                "IDMP-MAXSIZE must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX} entries, got: {size}"
             ));
         }
         Ok(Self {
@@ -313,11 +311,10 @@ impl StreamConfigOptions {
     /// # Errors
     /// Returns an error if seconds is not in the valid range `1..=86400`
     /// (see [`IDMP_DURATION_MIN`] and [`IDMP_DURATION_MAX`])
-    pub fn duration(mut self, seconds: u32) -> Result<Self, String> {
+    pub fn idempotency_seconds(mut self, seconds: u32) -> Result<Self, String> {
         if !(IDMP_DURATION_MIN..=IDMP_DURATION_MAX).contains(&seconds) {
             return Err(format!(
-                "IDMP-DURATION must be between {} and {} seconds, got: {}",
-                IDMP_DURATION_MIN, IDMP_DURATION_MAX, seconds
+                "IDMP-DURATION must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX} seconds, got: {seconds}"
             ));
         }
         self.idmp_duration = Some(seconds);
@@ -329,11 +326,10 @@ impl StreamConfigOptions {
     /// # Errors
     /// Returns an error if size is not in the valid range `1..=10000`
     /// (see [`IDMP_MAXSIZE_MIN`] and [`IDMP_MAXSIZE_MAX`])
-    pub fn maxsize(mut self, size: u16) -> Result<Self, String> {
+    pub fn idempotency_maxsize(mut self, size: u16) -> Result<Self, String> {
         if !(IDMP_MAXSIZE_MIN..=IDMP_MAXSIZE_MAX).contains(&size) {
             return Err(format!(
-                "IDMP-MAXSIZE must be between {} and {} entries, got: {}",
-                IDMP_MAXSIZE_MIN, IDMP_MAXSIZE_MAX, size
+                "IDMP-MAXSIZE must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX} entries, got: {size}"
             ));
         }
         self.idmp_maxsize = Some(size);
@@ -1853,41 +1849,60 @@ mod tests {
     mod stream_config_options {
         use super::*;
 
+        const IDMP_CUSTOM_DURATION: u32 = 300;
+        const IDMP_CUSTOM_MAXSIZE: u16 = 1000;
+
         #[test]
-        fn with_duration_only() {
-            let options = StreamConfigOptions::with_duration(300).unwrap();
-            assert_command_eq(options, b"IDMP-DURATION 300");
+        fn with_idempotency_seconds_only() {
+            let options =
+                StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION).unwrap();
+            assert_command_eq(
+                options,
+                format!("IDMP-DURATION {IDMP_CUSTOM_DURATION}").as_bytes(),
+            );
         }
 
         #[test]
-        fn with_maxsize_only() {
-            let options = StreamConfigOptions::with_maxsize(1000).unwrap();
-            assert_command_eq(options, b"IDMP-MAXSIZE 1000");
+        fn with_idempotency_maxsize_only() {
+            let options =
+                StreamConfigOptions::with_idempotency_maxsize(IDMP_CUSTOM_MAXSIZE).unwrap();
+            assert_command_eq(
+                options,
+                format!("IDMP-MAXSIZE {IDMP_CUSTOM_MAXSIZE}").as_bytes(),
+            );
         }
 
         #[test]
-        fn with_both_starting_duration() {
-            let options = StreamConfigOptions::with_duration(300)
+        fn with_both_options_starting_with_idempotency_seconds() {
+            let options = StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION)
                 .unwrap()
-                .maxsize(1000)
+                .idempotency_maxsize(IDMP_CUSTOM_MAXSIZE)
                 .unwrap();
-            assert_command_eq(options, b"IDMP-DURATION 300 IDMP-MAXSIZE 1000");
+            assert_command_eq(
+                options,
+                format!("IDMP-DURATION {IDMP_CUSTOM_DURATION} IDMP-MAXSIZE {IDMP_CUSTOM_MAXSIZE}")
+                    .as_bytes(),
+            );
         }
 
         #[test]
-        fn with_both_starting_maxsize() {
-            let options = StreamConfigOptions::with_maxsize(1000)
+        fn with_both_options_starting_with_idempotency_maxsize() {
+            let options = StreamConfigOptions::with_idempotency_maxsize(IDMP_CUSTOM_MAXSIZE)
                 .unwrap()
-                .duration(300)
+                .idempotency_seconds(IDMP_CUSTOM_DURATION)
                 .unwrap();
-            assert_command_eq(options, b"IDMP-DURATION 300 IDMP-MAXSIZE 1000");
+            assert_command_eq(
+                options,
+                format!("IDMP-DURATION {IDMP_CUSTOM_DURATION} IDMP-MAXSIZE {IDMP_CUSTOM_MAXSIZE}")
+                    .as_bytes(),
+            );
         }
 
         #[test]
         fn with_max_values() {
-            let options = StreamConfigOptions::with_duration(IDMP_DURATION_MAX)
+            let options = StreamConfigOptions::with_idempotency_seconds(IDMP_DURATION_MAX)
                 .unwrap()
-                .maxsize(IDMP_MAXSIZE_MAX)
+                .idempotency_maxsize(IDMP_MAXSIZE_MAX)
                 .unwrap();
             assert_command_eq(
                 options,
@@ -1898,9 +1913,9 @@ mod tests {
 
         #[test]
         fn with_min_values() {
-            let options = StreamConfigOptions::with_duration(IDMP_DURATION_MIN)
+            let options = StreamConfigOptions::with_idempotency_seconds(IDMP_DURATION_MIN)
                 .unwrap()
-                .maxsize(IDMP_MAXSIZE_MIN)
+                .idempotency_maxsize(IDMP_MAXSIZE_MIN)
                 .unwrap();
             assert_command_eq(
                 options,
@@ -1910,60 +1925,60 @@ mod tests {
         }
 
         #[test]
-        fn error_duration_too_low() {
-            let result = StreamConfigOptions::with_duration(IDMP_DURATION_MIN - 1);
+        fn error_idempotency_seconds_too_low() {
+            let result = StreamConfigOptions::with_idempotency_seconds(IDMP_DURATION_MIN - 1);
             assert!(result.is_err());
             assert!(result.unwrap_err().contains(&format!(
-                "must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
+                "IDMP-DURATION must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
             )));
         }
 
         #[test]
-        fn error_duration_too_high() {
-            let result = StreamConfigOptions::with_duration(IDMP_DURATION_MAX + 1);
+        fn error_idempotency_seconds_too_high() {
+            let result = StreamConfigOptions::with_idempotency_seconds(IDMP_DURATION_MAX + 1);
             assert!(result.is_err());
             assert!(result.unwrap_err().contains(&format!(
-                "must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
+                "IDMP-DURATION must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
             )));
         }
 
         #[test]
-        fn error_maxsize_too_low() {
-            let result = StreamConfigOptions::with_maxsize(IDMP_MAXSIZE_MIN - 1);
+        fn error_idempotency_maxsize_too_low() {
+            let result = StreamConfigOptions::with_idempotency_maxsize(IDMP_MAXSIZE_MIN - 1);
             assert!(result.is_err());
             assert!(result.unwrap_err().contains(&format!(
-                "must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
+                "IDMP-MAXSIZE must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
             )));
         }
 
         #[test]
-        fn error_maxsize_too_high() {
-            let result = StreamConfigOptions::with_maxsize(IDMP_MAXSIZE_MAX + 1);
+        fn error_idempotency_maxsize_too_high() {
+            let result = StreamConfigOptions::with_idempotency_maxsize(IDMP_MAXSIZE_MAX + 1);
             assert!(result.is_err());
             assert!(result.unwrap_err().contains(&format!(
-                "must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
+                "IDMP-MAXSIZE must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
             )));
         }
 
         #[test]
-        fn error_setter_duration_too_low() {
-            let result = StreamConfigOptions::with_maxsize(100)
+        fn error_setter_idempotency_seconds_too_low() {
+            let result = StreamConfigOptions::with_idempotency_maxsize(IDMP_CUSTOM_MAXSIZE)
                 .unwrap()
-                .duration(IDMP_DURATION_MIN - 1);
+                .idempotency_seconds(IDMP_DURATION_MIN - 1);
             assert!(result.is_err());
             assert!(result.unwrap_err().contains(&format!(
-                "must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
+                "IDMP-DURATION must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
             )));
         }
 
         #[test]
-        fn error_setter_maxsize_too_high() {
-            let result = StreamConfigOptions::with_duration(100)
+        fn error_setter_idempotency_maxsize_too_high() {
+            let result = StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION)
                 .unwrap()
-                .maxsize(IDMP_MAXSIZE_MAX + 1);
+                .idempotency_maxsize(IDMP_MAXSIZE_MAX + 1);
             assert!(result.is_err());
             assert!(result.unwrap_err().contains(&format!(
-                "must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
+                "IDMP-MAXSIZE must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
             )));
         }
     }

--- a/redis/src/commands/streams.rs
+++ b/redis/src/commands/streams.rs
@@ -216,6 +216,147 @@ impl ToRedisArgs for StreamIdempotencyMode {
     }
 }
 
+/// Minimum value for IDMP-DURATION parameter (1 second)
+pub const IDMP_DURATION_MIN: u32 = 1;
+/// Maximum value for IDMP-DURATION parameter (86400 seconds = 24 hours)
+pub const IDMP_DURATION_MAX: u32 = 86400;
+/// Minimum value for IDMP-MAXSIZE parameter (1 entry)
+pub const IDMP_MAXSIZE_MIN: u16 = 1;
+/// Maximum value for IDMP-MAXSIZE parameter (10000 entries)
+pub const IDMP_MAXSIZE_MAX: u16 = 10000;
+
+/// Configuration options for [`xcfgset`] command
+///
+/// Configures idempotency parameters for a stream.
+/// Use the constructor methods to create an instance with at least one parameter set,
+/// or use the setter methods to add parameters to an existing instance.
+///
+/// [`xcfgset`]: ../trait.Commands.html#method.xcfgset
+///
+/// # Example
+/// ```no_run
+/// use redis::{Commands, streams::StreamConfigOptions};
+/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+/// # let mut con = client.get_connection().unwrap();
+///
+/// // Create with duration, optionally add maxsize
+/// let opts1 = StreamConfigOptions::with_duration(300)
+///     .unwrap()
+///     .maxsize(1000)
+///     .unwrap();
+/// let _: String = con.xcfgset("key", &opts1).unwrap();
+///
+/// // Or create with maxsize only and optionally add duration
+/// let opts2 = StreamConfigOptions::with_maxsize(500)
+///     .unwrap()
+///     .duration(300)
+///     .unwrap();
+/// let _: String = con.xcfgset("key", &opts2).unwrap();
+/// ```
+#[derive(Debug)]
+pub struct StreamConfigOptions {
+    /// Duration in seconds that each idempotent ID is kept
+    ///
+    /// Valid range: `1..=86400` (see [`IDMP_DURATION_MIN`] and [`IDMP_DURATION_MAX`])
+    idmp_duration: Option<u32>,
+    /// Maximum number of idempotent IDs kept per producer
+    ///
+    /// Valid range: `1..=10000` (see [`IDMP_MAXSIZE_MIN`] and [`IDMP_MAXSIZE_MAX`])
+    idmp_maxsize: Option<u16>,
+}
+
+impl StreamConfigOptions {
+    /// Create configuration options with IDMP-DURATION parameter
+    ///
+    /// Sets the duration in seconds that each idempotent ID (iid) is kept
+    /// in the stream's IDMP map. Default: 100 seconds.
+    ///
+    /// # Errors
+    /// Returns an error if seconds is not in the valid range `1..=86400`
+    /// (see [`IDMP_DURATION_MIN`] and [`IDMP_DURATION_MAX`])
+    pub fn with_duration(seconds: u32) -> Result<Self, String> {
+        if !(IDMP_DURATION_MIN..=IDMP_DURATION_MAX).contains(&seconds) {
+            return Err(format!(
+                "IDMP-DURATION must be between {} and {} seconds, got: {}",
+                IDMP_DURATION_MIN, IDMP_DURATION_MAX, seconds
+            ));
+        }
+        Ok(Self {
+            idmp_duration: Some(seconds),
+            idmp_maxsize: None,
+        })
+    }
+
+    /// Create configuration options with IDMP-MAXSIZE parameter
+    ///
+    /// Sets the maximum number of most recent idempotent IDs kept for each
+    /// producer in the stream's IDMP map. Default: 100 entries.
+    ///
+    /// # Errors
+    /// Returns an error if size is not in the valid range `1..=10000`
+    /// (see [`IDMP_MAXSIZE_MIN`] and [`IDMP_MAXSIZE_MAX`])
+    pub fn with_maxsize(size: u16) -> Result<Self, String> {
+        if !(IDMP_MAXSIZE_MIN..=IDMP_MAXSIZE_MAX).contains(&size) {
+            return Err(format!(
+                "IDMP-MAXSIZE must be between {} and {} entries, got: {}",
+                IDMP_MAXSIZE_MIN, IDMP_MAXSIZE_MAX, size
+            ));
+        }
+        Ok(Self {
+            idmp_duration: None,
+            idmp_maxsize: Some(size),
+        })
+    }
+
+    /// Set or update the IDMP-DURATION parameter
+    ///
+    /// # Errors
+    /// Returns an error if seconds is not in the valid range `1..=86400`
+    /// (see [`IDMP_DURATION_MIN`] and [`IDMP_DURATION_MAX`])
+    pub fn duration(mut self, seconds: u32) -> Result<Self, String> {
+        if !(IDMP_DURATION_MIN..=IDMP_DURATION_MAX).contains(&seconds) {
+            return Err(format!(
+                "IDMP-DURATION must be between {} and {} seconds, got: {}",
+                IDMP_DURATION_MIN, IDMP_DURATION_MAX, seconds
+            ));
+        }
+        self.idmp_duration = Some(seconds);
+        Ok(self)
+    }
+
+    /// Set or update the IDMP-MAXSIZE parameter
+    ///
+    /// # Errors
+    /// Returns an error if size is not in the valid range `1..=10000`
+    /// (see [`IDMP_MAXSIZE_MIN`] and [`IDMP_MAXSIZE_MAX`])
+    pub fn maxsize(mut self, size: u16) -> Result<Self, String> {
+        if !(IDMP_MAXSIZE_MIN..=IDMP_MAXSIZE_MAX).contains(&size) {
+            return Err(format!(
+                "IDMP-MAXSIZE must be between {} and {} entries, got: {}",
+                IDMP_MAXSIZE_MIN, IDMP_MAXSIZE_MAX, size
+            ));
+        }
+        self.idmp_maxsize = Some(size);
+        Ok(self)
+    }
+}
+
+impl ToRedisArgs for StreamConfigOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        if let Some(duration) = self.idmp_duration {
+            out.write_arg(b"IDMP-DURATION");
+            out.write_arg(duration.to_string().as_bytes());
+        }
+        if let Some(maxsize) = self.idmp_maxsize {
+            out.write_arg(b"IDMP-MAXSIZE");
+            out.write_arg(maxsize.to_string().as_bytes());
+        }
+    }
+}
+
 /// Builder options for [`xadd_options`] command
 ///
 /// [`xadd_options`]: ../trait.Commands.html#method.xadd_options
@@ -693,7 +834,11 @@ pub struct StreamPendingCountReply {
 /// The very first and last IDs in the stream are shown,
 /// in order to give some sense about what is the stream content.
 ///
+/// **Note:** For Redis 8.6+ idempotency tracking fields, use [`StreamInfoStreamReplyWithIdempotency`]
+/// via the [`xinfo_stream_with_idempotency`] command instead.
+///
 /// [`xinfo_stream`]: ../trait.Commands.html#method.xinfo_stream
+/// [`xinfo_stream_with_idempotency`]: ../trait.Commands.html#method.xinfo_stream_with_idempotency
 ///
 #[derive(Default, Debug, Clone)]
 pub struct StreamInfoStreamReply {
@@ -711,6 +856,53 @@ pub struct StreamInfoStreamReply {
     pub first_entry: StreamId,
     /// The very last entry in the stream.
     pub last_entry: StreamId,
+}
+
+// TODO: Remove this type and extend StreamInfoStreamReply when creating the next major release.
+/// Reply type used with [`xinfo_stream_with_idempotency`] command (Redis 8.6+).
+///
+/// This type composes [`StreamInfoStreamReply`] with additional idempotency tracking fields
+/// introduced in Redis 8.6.
+///
+/// The base stream information is accessible via the `base` field, while idempotency
+/// fields are directly available as top-level fields.
+///
+/// [`xinfo_stream_with_idempotency`]: ../trait.Commands.html#method.xinfo_stream_with_idempotency
+///
+/// # Example
+/// ```no_run
+/// use redis::{Commands, streams::StreamInfoStreamReplyWithIdempotency};
+/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+/// # let mut con = client.get_connection().unwrap();
+///
+/// let info: StreamInfoStreamReplyWithIdempotency = con.xinfo_stream_with_idempotency("stream").unwrap();
+///
+/// // Access base stream info
+/// println!("Stream length: {}", info.base.length);
+/// println!("Last ID: {}", info.base.last_generated_id);
+///
+/// // Access idempotency tracking (Redis 8.6+)
+/// println!("Producers tracked: {}", info.pids_tracked);
+/// println!("Idempotent IDs tracked: {}", info.iids_tracked);
+/// println!("Duplicates prevented: {}", info.iids_duplicates);
+/// ```
+#[derive(Default, Debug, Clone)]
+#[non_exhaustive]
+pub struct StreamInfoStreamReplyWithIdempotency {
+    /// Base stream information
+    pub base: StreamInfoStreamReply,
+    /// The duration in seconds that idempotent IDs are retained in the stream's IDMP map
+    pub idmp_duration: u32,
+    /// The maximum number of idempotent IDs kept for each producer in the stream's IDMP map
+    pub idmp_maxsize: u16,
+    /// The number of unique producer IDs currently being tracked
+    pub pids_tracked: usize,
+    /// The total number of idempotent IDs currently stored across all producers
+    pub iids_tracked: usize,
+    /// The total count of idempotent IDs that have been added to the stream during its lifetime
+    pub iids_added: usize,
+    /// The total count of duplicate messages that were detected and prevented by IDMP
+    pub iids_duplicates: usize,
 }
 
 /// Reply type used with [`xinfo_consumer`] command, an array of every
@@ -1160,6 +1352,60 @@ impl FromRedisValue for StreamInfoStreamReply {
     }
 }
 
+impl FromRedisValue for StreamInfoStreamReplyWithIdempotency {
+    fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
+        let mut map: HashMap<String, Value> = from_redis_value(v)?;
+
+        // Parse base fields into the composed StreamInfoStreamReply
+        let mut base = StreamInfoStreamReply::default();
+        if let Some(v) = map.remove("last-generated-id") {
+            base.last_generated_id = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("radix-tree-nodes") {
+            base.radix_tree_keys = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("groups") {
+            base.groups = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("length") {
+            base.length = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("first-entry") {
+            base.first_entry = StreamId::from_array_value(v)?;
+        }
+        if let Some(v) = map.remove("last-entry") {
+            base.last_entry = StreamId::from_array_value(v)?;
+        }
+
+        // Parse idempotency fields
+        let mut reply = StreamInfoStreamReplyWithIdempotency {
+            base,
+            ..Default::default()
+        };
+
+        if let Some(v) = map.remove("idmp-duration") {
+            reply.idmp_duration = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("idmp-maxsize") {
+            reply.idmp_maxsize = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("pids-tracked") {
+            reply.pids_tracked = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("iids-tracked") {
+            reply.iids_tracked = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("iids-added") {
+            reply.iids_added = from_redis_value(v)?;
+        }
+        if let Some(v) = map.remove("iids-duplicates") {
+            reply.iids_duplicates = from_redis_value(v)?;
+        }
+
+        Ok(reply)
+    }
+}
+
 impl FromRedisValue for StreamInfoConsumersReply {
     fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
         let consumers: Vec<HashMap<String, Value>> = from_redis_value(v)?;
@@ -1601,6 +1847,124 @@ mod tests {
                 options,
                 b"NOMKSTREAM DELREF IDMPAUTO producer-2 MINID = 123456-0",
             );
+        }
+    }
+
+    mod stream_config_options {
+        use super::*;
+
+        #[test]
+        fn with_duration_only() {
+            let options = StreamConfigOptions::with_duration(300).unwrap();
+            assert_command_eq(options, b"IDMP-DURATION 300");
+        }
+
+        #[test]
+        fn with_maxsize_only() {
+            let options = StreamConfigOptions::with_maxsize(1000).unwrap();
+            assert_command_eq(options, b"IDMP-MAXSIZE 1000");
+        }
+
+        #[test]
+        fn with_both_starting_duration() {
+            let options = StreamConfigOptions::with_duration(300)
+                .unwrap()
+                .maxsize(1000)
+                .unwrap();
+            assert_command_eq(options, b"IDMP-DURATION 300 IDMP-MAXSIZE 1000");
+        }
+
+        #[test]
+        fn with_both_starting_maxsize() {
+            let options = StreamConfigOptions::with_maxsize(1000)
+                .unwrap()
+                .duration(300)
+                .unwrap();
+            assert_command_eq(options, b"IDMP-DURATION 300 IDMP-MAXSIZE 1000");
+        }
+
+        #[test]
+        fn with_max_values() {
+            let options = StreamConfigOptions::with_duration(IDMP_DURATION_MAX)
+                .unwrap()
+                .maxsize(IDMP_MAXSIZE_MAX)
+                .unwrap();
+            assert_command_eq(
+                options,
+                format!("IDMP-DURATION {IDMP_DURATION_MAX} IDMP-MAXSIZE {IDMP_MAXSIZE_MAX}")
+                    .as_bytes(),
+            );
+        }
+
+        #[test]
+        fn with_min_values() {
+            let options = StreamConfigOptions::with_duration(IDMP_DURATION_MIN)
+                .unwrap()
+                .maxsize(IDMP_MAXSIZE_MIN)
+                .unwrap();
+            assert_command_eq(
+                options,
+                format!("IDMP-DURATION {IDMP_DURATION_MIN} IDMP-MAXSIZE {IDMP_MAXSIZE_MIN}")
+                    .as_bytes(),
+            );
+        }
+
+        #[test]
+        fn error_duration_too_low() {
+            let result = StreamConfigOptions::with_duration(IDMP_DURATION_MIN - 1);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains(&format!(
+                "must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
+            )));
+        }
+
+        #[test]
+        fn error_duration_too_high() {
+            let result = StreamConfigOptions::with_duration(IDMP_DURATION_MAX + 1);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains(&format!(
+                "must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
+            )));
+        }
+
+        #[test]
+        fn error_maxsize_too_low() {
+            let result = StreamConfigOptions::with_maxsize(IDMP_MAXSIZE_MIN - 1);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains(&format!(
+                "must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
+            )));
+        }
+
+        #[test]
+        fn error_maxsize_too_high() {
+            let result = StreamConfigOptions::with_maxsize(IDMP_MAXSIZE_MAX + 1);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains(&format!(
+                "must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
+            )));
+        }
+
+        #[test]
+        fn error_setter_duration_too_low() {
+            let result = StreamConfigOptions::with_maxsize(100)
+                .unwrap()
+                .duration(IDMP_DURATION_MIN - 1);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains(&format!(
+                "must be between {IDMP_DURATION_MIN} and {IDMP_DURATION_MAX}"
+            )));
+        }
+
+        #[test]
+        fn error_setter_maxsize_too_high() {
+            let result = StreamConfigOptions::with_duration(100)
+                .unwrap()
+                .maxsize(IDMP_MAXSIZE_MAX + 1);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains(&format!(
+                "must be between {IDMP_MAXSIZE_MIN} and {IDMP_MAXSIZE_MAX}"
+            )));
         }
     }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -414,6 +414,7 @@ pub const REDIS_VERSION_CE_7_2: Version = (7, 2, 0);
 pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
 pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
 pub const REDIS_VERSION_CE_8_4: Version = (8, 3, 224);
+pub const REDIS_VERSION_CE_8_6: Version = (8, 6, 0);
 
 /// Macro to run tests only if the Redis version meets the minimum requirement.
 /// If the version is insufficient, the test is skipped with a message.

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -2374,3 +2374,252 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
         assert_eq!(reply.deleted_ids.len(), 0);
     }
 }
+
+#[test]
+fn test_xadd_idempotency_manual_mode() {
+    // Test IDMP (manual mode) - prevents messages with the same PID and IID from being added to the stream.
+    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+    let mut con = ctx.connection();
+
+    const STREAM_NAME: &str = "test_idmp_stream";
+    const FIELD_VALUES: [(&str, &str); 2] = [("field1", "value1"), ("field2", "value2")];
+    const PID_1: &str = "producer-1";
+    const PID_2: &str = "producer-2";
+    const IID_1: &str = "msg-1";
+    const IID_2: &str = "msg-2";
+
+    // Add a message with IDMP mode.
+    let mut opts = StreamAddOptions::default().idmp(PID_1, IID_1);
+    let id1: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
+        .unwrap();
+    assert!(id1.is_some());
+
+    // Trying to add the same message again with the same PID and IID should succeed.
+    // The message should be deduplicated and the ID of the original message should be returned.
+    let id2: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
+        .unwrap();
+    assert!(id2.is_some());
+
+    // Verify that the returned message ID is the same as the original message ID and that the stream only has one entry.
+    assert_eq!(id1, id2);
+    assert_eq!(con.xlen(STREAM_NAME), Ok(1));
+
+    // Even adding a different message with the same PID and IID should succeed and be deduplicated to the original message.
+    let id3: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[1], &opts)
+        .unwrap();
+    assert!(id3.is_some());
+    assert_eq!(id1, id3);
+    assert_eq!(con.xlen(STREAM_NAME), Ok(1));
+    let reply = con.xrange_all(STREAM_NAME).unwrap();
+    assert!(reply.ids[0].contains_key(FIELD_VALUES[0].0));
+
+    // Adding a different message with the same PID but different IID should succeed.
+    opts = opts.idmp(PID_1, IID_2);
+    let id4: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[1], &opts)
+        .unwrap();
+    assert!(id4.is_some());
+    assert_ne!(id1, id4);
+    assert_eq!(con.xlen(STREAM_NAME), Ok(2));
+
+    // Adding an existing message with an existing IID but non-existing PID should succeed.
+    opts = opts.idmp(PID_2, IID_1);
+    let id5: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
+        .unwrap();
+    assert!(id5.is_some());
+    assert_ne!(id1, id5);
+    assert_ne!(id4, id5);
+    assert_eq!(con.xlen(STREAM_NAME), Ok(3));
+}
+
+#[test]
+fn test_xadd_idempotency_automatic_mode() {
+    // Test IDMPAUTO (automatic mode) - prevents messages with the same PID and content from being added to the stream.
+    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+    let mut con = ctx.connection();
+
+    const STREAM_NAME: &str = "test_idmpauto_stream";
+    const FIELD_VALUES: [(&str, &str); 2] = [("field1", "value1"), ("field2", "value2")];
+    const PID_1: &str = "producer-1";
+    const PID_2: &str = "producer-2";
+
+    // Add a message with IDMPAUTO mode.
+    let opts = StreamAddOptions::default().idmpauto(PID_1);
+    let id1: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
+        .unwrap();
+    assert!(id1.is_some());
+
+    // Adding the same message again should be deduplicated, returning the ID of the original message,
+    // because identical producer and content values result in the same auto-generated ID.
+    let id2: Option<String> = con
+        .xadd_options(
+            STREAM_NAME,
+            "*",
+            &FIELD_VALUES[0], // Same content
+            &opts,
+        )
+        .unwrap();
+    assert!(id2.is_some());
+
+    // Verify that the returned message ID is the same as the original message ID and that the stream only has one entry.
+    assert_eq!(id1, id2);
+    assert_eq!(con.xlen(STREAM_NAME), Ok(1));
+
+    // Adding a message with different content should succeed.
+    let id3: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[1], &opts)
+        .unwrap();
+    assert!(id3.is_some());
+    assert_ne!(id1, id3);
+    assert_eq!(con.xlen(STREAM_NAME), Ok(2));
+
+    // Adding an existing message with different PID should succeed.
+    let id4: Option<String> = con
+        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts.idmpauto(PID_2))
+        .unwrap();
+    assert!(id4.is_some());
+    assert_ne!(id1, id4);
+    assert_ne!(id3, id4);
+    assert_eq!(con.xlen(STREAM_NAME), Ok(3));
+}
+
+#[test]
+fn test_xadd_idempotency_with_other_options() {
+    // Test that idempotency works correctly with other XADD options
+    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+    let mut con = ctx.connection();
+
+    const STREAM_NAME: &str = "test_idmp_combined";
+    const GROUP_NAME: &str = "test_group";
+    const CONSUMER_NAME: &str = "consumer";
+    const PID: &str = "producer-1";
+    const IID: &str = "msg-1";
+
+    const INITIAL_STREAM_ENTRIES: [(&str, &str); 3] = [
+        ("field1", "value1"),
+        ("field2", "value2"),
+        ("field3", "value3"),
+    ];
+    const ADDITIONAL_STREAM_ENTRY: (&str, &str) = ("field4", "value4");
+    const FINAL_STREAM_ENTRY: (&str, &str) = ("field5", "value5");
+
+    // Test that NOMKSTREAM does not create the stream if it doesn't exist.
+    let result = con.xadd_options(
+        STREAM_NAME,
+        "*",
+        &[("field", "value")],
+        &StreamAddOptions::default().idmp(PID, IID).nomkstream(),
+    );
+    assert_eq!(result, Ok(None));
+
+    // Verify that the stream did not get created.
+    let result = con.xinfo_stream(STREAM_NAME);
+    assert_matches!(&result, Err(e) if e.kind() == redis::ServerErrorKind::ResponseError.into()
+        && e.code() == Some("ERR")
+        && e.detail() == Some("no such key")
+    );
+
+    // Create stream with initial entries.
+    let [_id1, id2, id3]: [String; 3] =
+        INITIAL_STREAM_ENTRIES.map(|entry| con.xadd(STREAM_NAME, "*", &[entry]).unwrap().unwrap());
+
+    // Create a consumer group and read all initial messages to create PEL entries.
+    let _: () = con
+        .xgroup_create_mkstream(STREAM_NAME, GROUP_NAME, "0")
+        .unwrap();
+    let _: Option<StreamReadReply> = con
+        .xread_options(
+            &[STREAM_NAME],
+            &[">"],
+            &StreamReadOptions::default()
+                .group(GROUP_NAME, CONSUMER_NAME)
+                .count(INITIAL_STREAM_ENTRIES.len() + 1),
+        )
+        .unwrap();
+    let pending = con.xpending(STREAM_NAME, GROUP_NAME).unwrap();
+    assert_eq!(pending.count(), INITIAL_STREAM_ENTRIES.len());
+
+    // Add the additional entry with idempotency, apply trimming and deletion policy.
+    // This should trim the stream and keep references in PEL.
+    let id4 = con
+        .xadd_options(
+            STREAM_NAME,
+            "*",
+            &[ADDITIONAL_STREAM_ENTRY],
+            &StreamAddOptions::default()
+                .idmp(PID, IID)
+                .trim(StreamTrimStrategy::maxlen(
+                    StreamTrimmingMode::Exact,
+                    INITIAL_STREAM_ENTRIES.len(),
+                ))
+                .set_deletion_policy(StreamDeletionPolicy::KeepRef),
+        )
+        .unwrap()
+        .unwrap();
+
+    // The stream should have been trimmed as its entries exceeded the maximum length.
+    // As a result, the first entry should have been removed.
+    assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
+    let info = con.xinfo_stream(STREAM_NAME).unwrap();
+    assert_eq!(info.first_entry.id, id2);
+    assert_eq!(info.last_generated_id, id4);
+
+    // References should still exist in PEL (KeepRef policy).
+    let pending = con.xpending(STREAM_NAME, GROUP_NAME).unwrap();
+    assert_eq!(pending.count(), INITIAL_STREAM_ENTRIES.len());
+
+    // Trying to add the same message again with the same PID and IID should succeed.
+    // The message should be deduplicated and the ID of the original message should be returned.
+    let id5 = con
+        .xadd_options(
+            STREAM_NAME,
+            "*",
+            &[ADDITIONAL_STREAM_ENTRY],
+            &StreamAddOptions::default()
+                .idmp(PID, IID)
+                .trim(StreamTrimStrategy::maxlen(
+                    StreamTrimmingMode::Exact,
+                    INITIAL_STREAM_ENTRIES.len(),
+                ))
+                .set_deletion_policy(StreamDeletionPolicy::KeepRef),
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(id4, id5);
+
+    // The stream should remain unchanged.
+    assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
+    let info = con.xinfo_stream(STREAM_NAME).unwrap();
+    assert_eq!(info.first_entry.id, id2);
+    assert_eq!(info.last_generated_id, id4);
+
+    // Adding another message with different IID (generated by automatic mode) - should succeed and trim further.
+    let id6 = con
+        .xadd_options(
+            STREAM_NAME,
+            "*",
+            &[FINAL_STREAM_ENTRY],
+            &StreamAddOptions::default()
+                .idmpauto(PID)
+                .trim(StreamTrimStrategy::maxlen(
+                    StreamTrimmingMode::Exact,
+                    INITIAL_STREAM_ENTRIES.len(),
+                ))
+                .set_deletion_policy(StreamDeletionPolicy::KeepRef),
+        )
+        .unwrap()
+        .unwrap();
+    assert_ne!(id5, id6);
+
+    // The stream should have been trimmed again, as its entries once again exceeded the maximum length.
+    // As a result, the first entry (second from the initial entries) should have been removed.
+    assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
+    let info = con.xinfo_stream(STREAM_NAME).unwrap();
+    assert_eq!(info.first_entry.id, id3); // id2 should now be trimmed
+    assert_eq!(info.last_generated_id, id6);
+}

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -2375,251 +2375,654 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
     }
 }
 
-#[test]
-fn test_xadd_idempotency_manual_mode() {
-    // Test IDMP (manual mode) - prevents messages with the same PID and IID from being added to the stream.
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
-    let mut con = ctx.connection();
+mod idempotency_tests {
+    use super::*;
 
-    const STREAM_NAME: &str = "test_idmp_stream";
-    const FIELD_VALUES: [(&str, &str); 2] = [("field1", "value1"), ("field2", "value2")];
     const PID_1: &str = "producer-1";
     const PID_2: &str = "producer-2";
     const IID_1: &str = "msg-1";
     const IID_2: &str = "msg-2";
 
-    // Add a message with IDMP mode.
-    let mut opts = StreamAddOptions::default().idmp(PID_1, IID_1);
-    let id1: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
-        .unwrap();
-    assert!(id1.is_some());
+    const IDMP_DEFAULT_DURATION: u32 = 100;
+    const IDMP_DEFAULT_MAXSIZE: u16 = 100;
 
-    // Trying to add the same message again with the same PID and IID should succeed.
-    // The message should be deduplicated and the ID of the original message should be returned.
-    let id2: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
-        .unwrap();
-    assert!(id2.is_some());
+    const IDMP_CUSTOM_DURATION: u32 = 300;
+    const IDMP_CUSTOM_MAXSIZE: u16 = 500;
 
-    // Verify that the returned message ID is the same as the original message ID and that the stream only has one entry.
-    assert_eq!(id1, id2);
-    assert_eq!(con.xlen(STREAM_NAME), Ok(1));
-
-    // Even adding a different message with the same PID and IID should succeed and be deduplicated to the original message.
-    let id3: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[1], &opts)
-        .unwrap();
-    assert!(id3.is_some());
-    assert_eq!(id1, id3);
-    assert_eq!(con.xlen(STREAM_NAME), Ok(1));
-    let reply = con.xrange_all(STREAM_NAME).unwrap();
-    assert!(reply.ids[0].contains_key(FIELD_VALUES[0].0));
-
-    // Adding a different message with the same PID but different IID should succeed.
-    opts = opts.idmp(PID_1, IID_2);
-    let id4: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[1], &opts)
-        .unwrap();
-    assert!(id4.is_some());
-    assert_ne!(id1, id4);
-    assert_eq!(con.xlen(STREAM_NAME), Ok(2));
-
-    // Adding an existing message with an existing IID but non-existing PID should succeed.
-    opts = opts.idmp(PID_2, IID_1);
-    let id5: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
-        .unwrap();
-    assert!(id5.is_some());
-    assert_ne!(id1, id5);
-    assert_ne!(id4, id5);
-    assert_eq!(con.xlen(STREAM_NAME), Ok(3));
-}
-
-#[test]
-fn test_xadd_idempotency_automatic_mode() {
-    // Test IDMPAUTO (automatic mode) - prevents messages with the same PID and content from being added to the stream.
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
-    let mut con = ctx.connection();
-
-    const STREAM_NAME: &str = "test_idmpauto_stream";
     const FIELD_VALUES: [(&str, &str); 2] = [("field1", "value1"), ("field2", "value2")];
-    const PID_1: &str = "producer-1";
-    const PID_2: &str = "producer-2";
 
-    // Add a message with IDMPAUTO mode.
-    let opts = StreamAddOptions::default().idmpauto(PID_1);
-    let id1: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts)
-        .unwrap();
-    assert!(id1.is_some());
+    #[test]
+    fn test_xadd_idempotency_manual_mode() {
+        // Test IDMP (manual mode) - prevents messages with the same PID and IID from being added to the stream.
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = ctx.connection();
 
-    // Adding the same message again should be deduplicated, returning the ID of the original message,
-    // because identical producer and content values result in the same auto-generated ID.
-    let id2: Option<String> = con
-        .xadd_options(
+        const STREAM_NAME: &str = "test_idmp_stream";
+
+        // Add a message with IDMP mode.
+        let mut opts = StreamAddOptions::default().idmp(PID_1, IID_1);
+        let id1: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts)
+            .unwrap();
+        assert!(id1.is_some());
+        // Verify that the message was registered for tracking.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 0);
+
+        // Trying to add the same message again with the same PID and IID should succeed.
+        // The message should be deduplicated and the ID of the original message should be returned.
+        let id2: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts)
+            .unwrap();
+        assert!(id2.is_some());
+
+        // Verify that the returned message ID is the same as the original message ID and that the stream only has one entry.
+        assert_eq!(id1, id2);
+        assert_eq!(con.xlen(STREAM_NAME), Ok(1));
+        // Verify that deduplication has taken place.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 1);
+
+        // Even adding a different message with the same PID and IID should succeed and be deduplicated to the original message.
+        let id3: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[1], &opts)
+            .unwrap();
+        assert!(id3.is_some());
+        assert_eq!(id1, id3);
+        assert_eq!(con.xlen(STREAM_NAME), Ok(1));
+        let reply = con.xrange_all(STREAM_NAME).unwrap();
+        assert!(reply.ids[0].contains_key(FIELD_VALUES[0].0));
+        // Verify that deduplication has taken place.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 2);
+
+        // Adding a different message with the same PID but different IID should succeed.
+        opts = opts.idmp(PID_1, IID_2);
+        let id4: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[1], &opts)
+            .unwrap();
+        assert!(id4.is_some());
+        assert_ne!(id1, id4);
+        assert_eq!(con.xlen(STREAM_NAME), Ok(2));
+        // Verify that the message was registered for tracking.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 2);
+        assert_eq!(info.iids_duplicates, 2);
+
+        // Adding an existing message with an existing IID but non-existing PID should succeed.
+        opts = opts.idmp(PID_2, IID_1);
+        let id5: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts)
+            .unwrap();
+        assert!(id5.is_some());
+        assert_ne!(id1, id5);
+        assert_ne!(id4, id5);
+        assert_eq!(con.xlen(STREAM_NAME), Ok(3));
+        // Verify that the message was registered for tracking.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 2);
+        assert_eq!(info.iids_tracked, 3);
+        assert_eq!(info.iids_duplicates, 2);
+    }
+
+    #[test]
+    fn test_xadd_idempotency_automatic_mode() {
+        // Test IDMPAUTO (automatic mode) - prevents messages with the same PID and content from being added to the stream.
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = ctx.connection();
+
+        const STREAM_NAME: &str = "test_idmpauto_stream";
+
+        // Add a message with IDMPAUTO mode.
+        let opts = StreamAddOptions::default().idmpauto(PID_1);
+        let id1: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts)
+            .unwrap();
+        assert!(id1.is_some());
+        // Verify that the message was registered for tracking.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 0);
+
+        // Adding the same message again should be deduplicated, returning the ID of the original message,
+        // as identical producer and content produce the same auto-generated ID.
+        let id2: Option<String> = con
+            .xadd_options(
+                STREAM_NAME,
+                "*",
+                FIELD_VALUES[0], // Same content
+                &opts,
+            )
+            .unwrap();
+        assert!(id2.is_some());
+
+        // Verify that the returned message ID is the same as the original message ID and that the stream only has one entry.
+        assert_eq!(id1, id2);
+        assert_eq!(con.xlen(STREAM_NAME), Ok(1));
+        // Verify that deduplication has taken place.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 1);
+
+        // Adding a message with different content should succeed.
+        let id3: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[1], &opts)
+            .unwrap();
+        assert!(id3.is_some());
+        assert_ne!(id1, id3);
+        assert_eq!(con.xlen(STREAM_NAME), Ok(2));
+        // Verify that the message was registered for tracking.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 2);
+        assert_eq!(info.iids_duplicates, 1);
+
+        // Adding an existing message with different PID should succeed.
+        let id4: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts.idmpauto(PID_2))
+            .unwrap();
+        assert!(id4.is_some());
+        assert_ne!(id1, id4);
+        assert_ne!(id3, id4);
+        assert_eq!(con.xlen(STREAM_NAME), Ok(3));
+        // Verify that the message was registered for tracking.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 2);
+        assert_eq!(info.iids_tracked, 3);
+        assert_eq!(info.iids_duplicates, 1);
+    }
+
+    #[test]
+    fn test_xadd_idempotency_with_other_options() {
+        // Test that idempotency works correctly with other XADD options
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = ctx.connection();
+
+        const STREAM_NAME: &str = "test_idmp_combined_options_stream";
+        const GROUP_NAME: &str = "test_group";
+        const CONSUMER_NAME: &str = "consumer";
+
+        const INITIAL_STREAM_ENTRIES: [(&str, &str); 3] = [
+            ("field1", "value1"),
+            ("field2", "value2"),
+            ("field3", "value3"),
+        ];
+        const ADDITIONAL_STREAM_ENTRY: (&str, &str) = ("field4", "value4");
+        const FINAL_STREAM_ENTRY: (&str, &str) = ("field5", "value5");
+
+        // Test that NOMKSTREAM does not create the stream if it doesn't exist.
+        let result = con.xadd_options(
             STREAM_NAME,
             "*",
-            &FIELD_VALUES[0], // Same content
-            &opts,
-        )
-        .unwrap();
-    assert!(id2.is_some());
+            &[("field", "value")],
+            &StreamAddOptions::default().idmp(PID_1, IID_1).nomkstream(),
+        );
+        assert_eq!(result, Ok(None));
 
-    // Verify that the returned message ID is the same as the original message ID and that the stream only has one entry.
-    assert_eq!(id1, id2);
-    assert_eq!(con.xlen(STREAM_NAME), Ok(1));
+        // Verify that the stream did not get created.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME);
+        assert_matches!(&info, Err(e) if e.kind() == redis::ServerErrorKind::ResponseError.into()
+            && e.code() == Some("ERR")
+            && e.detail() == Some("no such key")
+        );
 
-    // Adding a message with different content should succeed.
-    let id3: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[1], &opts)
-        .unwrap();
-    assert!(id3.is_some());
-    assert_ne!(id1, id3);
-    assert_eq!(con.xlen(STREAM_NAME), Ok(2));
+        // Create stream with initial entries.
+        let [_id1, id2, id3]: [String; 3] = INITIAL_STREAM_ENTRIES
+            .map(|entry| con.xadd(STREAM_NAME, "*", &[entry]).unwrap().unwrap());
 
-    // Adding an existing message with different PID should succeed.
-    let id4: Option<String> = con
-        .xadd_options(STREAM_NAME, "*", &FIELD_VALUES[0], &opts.idmpauto(PID_2))
-        .unwrap();
-    assert!(id4.is_some());
-    assert_ne!(id1, id4);
-    assert_ne!(id3, id4);
-    assert_eq!(con.xlen(STREAM_NAME), Ok(3));
-}
+        // Verify that since idempotency was not used, no tracking of the messages has taken place.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 0);
+        assert_eq!(info.iids_tracked, 0);
+        assert_eq!(info.iids_duplicates, 0);
 
-#[test]
-fn test_xadd_idempotency_with_other_options() {
-    // Test that idempotency works correctly with other XADD options
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
-    let mut con = ctx.connection();
+        // Create a consumer group and read all initial messages to create PEL entries.
+        let _: () = con
+            .xgroup_create_mkstream(STREAM_NAME, GROUP_NAME, "0")
+            .unwrap();
+        let _: Option<StreamReadReply> = con
+            .xread_options(
+                &[STREAM_NAME],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(GROUP_NAME, CONSUMER_NAME)
+                    .count(INITIAL_STREAM_ENTRIES.len() + 1),
+            )
+            .unwrap();
+        let pending = con.xpending(STREAM_NAME, GROUP_NAME).unwrap();
+        assert_eq!(pending.count(), INITIAL_STREAM_ENTRIES.len());
 
-    const STREAM_NAME: &str = "test_idmp_combined";
-    const GROUP_NAME: &str = "test_group";
-    const CONSUMER_NAME: &str = "consumer";
-    const PID: &str = "producer-1";
-    const IID: &str = "msg-1";
+        // Add the additional entry with idempotency, apply trimming and deletion policy.
+        // This should trim the stream and keep references in PEL.
+        let id4 = con
+            .xadd_options(
+                STREAM_NAME,
+                "*",
+                &[ADDITIONAL_STREAM_ENTRY],
+                &StreamAddOptions::default()
+                    .idmp(PID_1, IID_1)
+                    .trim(StreamTrimStrategy::maxlen(
+                        StreamTrimmingMode::Exact,
+                        INITIAL_STREAM_ENTRIES.len(),
+                    ))
+                    .set_deletion_policy(StreamDeletionPolicy::KeepRef),
+            )
+            .unwrap()
+            .unwrap();
 
-    const INITIAL_STREAM_ENTRIES: [(&str, &str); 3] = [
-        ("field1", "value1"),
-        ("field2", "value2"),
-        ("field3", "value3"),
-    ];
-    const ADDITIONAL_STREAM_ENTRY: (&str, &str) = ("field4", "value4");
-    const FINAL_STREAM_ENTRY: (&str, &str) = ("field5", "value5");
+        // The stream should have been trimmed as its entries exceeded the maximum length.
+        // As a result, the first entry should have been removed.
+        assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.base.first_entry.id, id2); // id1 should now be trimmed
+        assert_eq!(info.base.last_generated_id, id4);
+        // Additionally, verify that the message was registered for idempotency tracking.
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 0);
 
-    // Test that NOMKSTREAM does not create the stream if it doesn't exist.
-    let result = con.xadd_options(
-        STREAM_NAME,
-        "*",
-        &[("field", "value")],
-        &StreamAddOptions::default().idmp(PID, IID).nomkstream(),
-    );
-    assert_eq!(result, Ok(None));
+        // References should still exist in PEL (KeepRef policy).
+        let pending = con.xpending(STREAM_NAME, GROUP_NAME).unwrap();
+        assert_eq!(pending.count(), INITIAL_STREAM_ENTRIES.len());
 
-    // Verify that the stream did not get created.
-    let result = con.xinfo_stream(STREAM_NAME);
-    assert_matches!(&result, Err(e) if e.kind() == redis::ServerErrorKind::ResponseError.into()
-        && e.code() == Some("ERR")
-        && e.detail() == Some("no such key")
-    );
+        // Trying to add the same message again with the same PID and IID should succeed.
+        // The message should be deduplicated and the ID of the original message should be returned.
+        let id5 = con
+            .xadd_options(
+                STREAM_NAME,
+                "*",
+                &[ADDITIONAL_STREAM_ENTRY],
+                &StreamAddOptions::default()
+                    .idmp(PID_1, IID_1)
+                    .trim(StreamTrimStrategy::maxlen(
+                        StreamTrimmingMode::Exact,
+                        INITIAL_STREAM_ENTRIES.len(),
+                    ))
+                    .set_deletion_policy(StreamDeletionPolicy::KeepRef),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(id4, id5);
 
-    // Create stream with initial entries.
-    let [_id1, id2, id3]: [String; 3] =
-        INITIAL_STREAM_ENTRIES.map(|entry| con.xadd(STREAM_NAME, "*", &[entry]).unwrap().unwrap());
+        // The stream should remain unchanged.
+        assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.base.first_entry.id, id2);
+        assert_eq!(info.base.last_generated_id, id4);
+        // Additionally, verify that the message was deduplicated.
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 1);
 
-    // Create a consumer group and read all initial messages to create PEL entries.
-    let _: () = con
-        .xgroup_create_mkstream(STREAM_NAME, GROUP_NAME, "0")
-        .unwrap();
-    let _: Option<StreamReadReply> = con
-        .xread_options(
-            &[STREAM_NAME],
-            &[">"],
-            &StreamReadOptions::default()
-                .group(GROUP_NAME, CONSUMER_NAME)
-                .count(INITIAL_STREAM_ENTRIES.len() + 1),
-        )
-        .unwrap();
-    let pending = con.xpending(STREAM_NAME, GROUP_NAME).unwrap();
-    assert_eq!(pending.count(), INITIAL_STREAM_ENTRIES.len());
+        // Adding another message with different IID (generated by automatic mode) - should succeed and trim further.
+        let id6 = con
+            .xadd_options(
+                STREAM_NAME,
+                "*",
+                &[FINAL_STREAM_ENTRY],
+                &StreamAddOptions::default()
+                    .idmpauto(PID_1)
+                    .trim(StreamTrimStrategy::maxlen(
+                        StreamTrimmingMode::Exact,
+                        INITIAL_STREAM_ENTRIES.len(),
+                    ))
+                    .set_deletion_policy(StreamDeletionPolicy::KeepRef),
+            )
+            .unwrap()
+            .unwrap();
+        assert_ne!(id5, id6);
 
-    // Add the additional entry with idempotency, apply trimming and deletion policy.
-    // This should trim the stream and keep references in PEL.
-    let id4 = con
-        .xadd_options(
+        // The stream should have been trimmed again, as its entries once again exceeded the maximum length.
+        // As a result, the first entry (second from the initial entries) should have been removed.
+        assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.base.first_entry.id, id3); // id2 should now be trimmed
+        assert_eq!(info.base.last_generated_id, id6);
+        // Additionally, verify that the message was registered for idempotency tracking.
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 2);
+        assert_eq!(info.iids_duplicates, 1);
+    }
+
+    #[test]
+    fn test_xcfgset() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = ctx.connection();
+
+        const STREAM_NAME: &str = "test_xcfgset_stream";
+        const KEY_VALUE: (&str, &str) = ("test", "test");
+
+        // Trying to configure a non-existent stream should return an error.
+        let result: redis::RedisResult<String> = con.xcfgset(
             STREAM_NAME,
-            "*",
-            &[ADDITIONAL_STREAM_ENTRY],
-            &StreamAddOptions::default()
-                .idmp(PID, IID)
-                .trim(StreamTrimStrategy::maxlen(
-                    StreamTrimmingMode::Exact,
-                    INITIAL_STREAM_ENTRIES.len(),
-                ))
-                .set_deletion_policy(StreamDeletionPolicy::KeepRef),
-        )
-        .unwrap()
-        .unwrap();
+            &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap(),
+        );
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e.code(), Some("ERR"));
+            assert!(e.to_string().contains("no such key"));
+        }
+        // An error should be returned if the key is not a stream.
+        assert_eq!(con.set(KEY_VALUE.0, KEY_VALUE.1), Ok(()));
+        let result: redis::RedisResult<String> = con.xcfgset(
+            KEY_VALUE.0,
+            &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap(),
+        );
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e.code(), Some("WRONGTYPE"));
+        }
 
-    // The stream should have been trimmed as its entries exceeded the maximum length.
-    // As a result, the first entry should have been removed.
-    assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
-    let info = con.xinfo_stream(STREAM_NAME).unwrap();
-    assert_eq!(info.first_entry.id, id2);
-    assert_eq!(info.last_generated_id, id4);
+        // Create an empty stream, using XGROUP CREATE MKSTREAM.
+        let _: () = con
+            .xgroup_create_mkstream(STREAM_NAME, "group", "$")
+            .unwrap();
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        // Verify that initially the defaults are used.
+        assert_eq!(info.idmp_duration, IDMP_DEFAULT_DURATION);
+        assert_eq!(info.idmp_maxsize, IDMP_DEFAULT_MAXSIZE);
 
-    // References should still exist in PEL (KeepRef policy).
-    let pending = con.xpending(STREAM_NAME, GROUP_NAME).unwrap();
-    assert_eq!(pending.count(), INITIAL_STREAM_ENTRIES.len());
+        // Configure with duration only.
+        assert_eq!(
+            con.xcfgset(
+                STREAM_NAME,
+                &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap()
+            )
+            .unwrap(),
+            "OK"
+        );
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        // Verify that only the duration has changed.
+        assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
+        assert_eq!(info.idmp_maxsize, IDMP_DEFAULT_MAXSIZE);
 
-    // Trying to add the same message again with the same PID and IID should succeed.
-    // The message should be deduplicated and the ID of the original message should be returned.
-    let id5 = con
-        .xadd_options(
-            STREAM_NAME,
-            "*",
-            &[ADDITIONAL_STREAM_ENTRY],
-            &StreamAddOptions::default()
-                .idmp(PID, IID)
-                .trim(StreamTrimStrategy::maxlen(
-                    StreamTrimmingMode::Exact,
-                    INITIAL_STREAM_ENTRIES.len(),
-                ))
-                .set_deletion_policy(StreamDeletionPolicy::KeepRef),
-        )
-        .unwrap()
-        .unwrap();
-    assert_eq!(id4, id5);
+        // Configure with maxsize only.
+        assert_eq!(
+            con.xcfgset(
+                STREAM_NAME,
+                &StreamConfigOptions::with_maxsize(IDMP_CUSTOM_MAXSIZE).unwrap()
+            )
+            .unwrap(),
+            "OK"
+        );
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        // Verify that the new max size is applied and that the previously set duration is preserved.
+        assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
+        assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
 
-    // The stream should remain unchanged.
-    assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
-    let info = con.xinfo_stream(STREAM_NAME).unwrap();
-    assert_eq!(info.first_entry.id, id2);
-    assert_eq!(info.last_generated_id, id4);
+        // Configure with both parameters, by first setting the duration and then the maxsize.
+        let opts = StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION * 2)
+            .unwrap()
+            .maxsize(IDMP_CUSTOM_MAXSIZE * 2)
+            .unwrap();
+        assert_eq!(con.xcfgset(STREAM_NAME, &opts).unwrap(), "OK");
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        // Verify that both parameters have changed and they are now doubled.
+        assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION * 2);
+        assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE * 2);
 
-    // Adding another message with different IID (generated by automatic mode) - should succeed and trim further.
-    let id6 = con
-        .xadd_options(
-            STREAM_NAME,
-            "*",
-            &[FINAL_STREAM_ENTRY],
-            &StreamAddOptions::default()
-                .idmpauto(PID)
-                .trim(StreamTrimStrategy::maxlen(
-                    StreamTrimmingMode::Exact,
-                    INITIAL_STREAM_ENTRIES.len(),
-                ))
-                .set_deletion_policy(StreamDeletionPolicy::KeepRef),
-        )
-        .unwrap()
-        .unwrap();
-    assert_ne!(id5, id6);
+        // Configure with both parameters, by first setting the maxsize and then the duration.
+        let opts = StreamConfigOptions::with_maxsize(IDMP_CUSTOM_MAXSIZE)
+            .unwrap()
+            .duration(IDMP_CUSTOM_DURATION)
+            .unwrap();
+        assert_eq!(con.xcfgset(STREAM_NAME, &opts).unwrap(), "OK");
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        // Verify that both parameters have changed and they are now set to the custom values.
+        assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
+        assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
+    }
 
-    // The stream should have been trimmed again, as its entries once again exceeded the maximum length.
-    // As a result, the first entry (second from the initial entries) should have been removed.
-    assert_eq!(con.xlen(STREAM_NAME).unwrap(), INITIAL_STREAM_ENTRIES.len());
-    let info = con.xinfo_stream(STREAM_NAME).unwrap();
-    assert_eq!(info.first_entry.id, id3); // id2 should now be trimmed
-    assert_eq!(info.last_generated_id, id6);
+    #[test]
+    fn test_xcfgset_with_idempotent_messages() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = ctx.connection();
+
+        const STREAM_NAME: &str = "test_xcfgset_with_idempotent_messages_stream";
+
+        // Add the first idempotent message.
+        let opts1 = StreamAddOptions::default().idmp(PID_1, IID_1);
+        let id1: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts1)
+            .unwrap();
+        assert!(id1.is_some());
+
+        // Add the second idempotent message with different IID.
+        let opts2 = StreamAddOptions::default().idmp(PID_1, IID_2);
+        let id2: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[1], &opts2)
+            .unwrap();
+        assert!(id2.is_some());
+
+        // Verify that the IDMP map is populated.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 2);
+        assert_eq!(info.iids_added, 2);
+        assert_eq!(info.iids_duplicates, 0);
+
+        // Verify duplicates are properly detected before clearing.
+        let id3: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts1)
+            .unwrap();
+        assert!(id3.is_some());
+        assert_eq!(id1, id3);
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.iids_duplicates, 1);
+
+        // Changing the configuration should clear the IDMP map.
+        assert_eq!(
+            con.xcfgset(
+                STREAM_NAME,
+                &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap()
+            )
+            .unwrap(),
+            "OK"
+        );
+
+        // Verify that the configuration was applied and the IDMP map was cleared.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.idmp_duration, IDMP_CUSTOM_DURATION);
+        assert_eq!(info.pids_tracked, 0);
+        assert_eq!(info.iids_tracked, 0);
+        // Reminder: iids_added and iids_duplicates are lifetime counters and should NOT be reset when the map is cleared.
+        assert_eq!(info.iids_added, 2, "Lifetime counter should not be reset");
+        assert_eq!(
+            info.iids_duplicates, 1,
+            "Lifetime counter should not be reset"
+        );
+
+        // After clearing, the same message should NOT be detected as duplicate.
+        let id4: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts1)
+            .unwrap();
+        assert!(id4.is_some());
+        assert_ne!(id1, id4);
+
+        // Verify the IDMP map is now tracking again.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_added, 3);
+        assert_eq!(info.iids_duplicates, 1);
+
+        // Now the duplicate should be detected again.
+        let id5: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts1)
+            .unwrap();
+        assert!(id5.is_some());
+        assert_eq!(id4, id5);
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.iids_duplicates, 2);
+
+        // Verify that changing maxsize also clears the IDMP map.
+        assert_eq!(
+            con.xcfgset(
+                STREAM_NAME,
+                &StreamConfigOptions::with_maxsize(IDMP_CUSTOM_MAXSIZE).unwrap()
+            )
+            .unwrap(),
+            "OK"
+        );
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
+        assert_eq!(info.pids_tracked, 0);
+        assert_eq!(info.iids_tracked, 0);
+        assert_eq!(info.iids_added, 3, "Lifetime counter should not be reset");
+        assert_eq!(
+            info.iids_duplicates, 2,
+            "Lifetime counter should not be reset"
+        );
+    }
+
+    #[test]
+    fn test_xcfgset_idempotency_behavior() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = ctx.connection();
+
+        const STREAM_NAME: &str = "test_xcfgset_behavior_stream";
+        const IID_3: &str = "msg-3";
+
+        const IDMP_SHORT_DURATION: u32 = 2;
+        const IDMP_MAXSIZE_LIMIT: u16 = 2;
+        const EXTRA_FIELD_VALUE: (&str, &str) = ("extra-field", "extra-value");
+
+        // Test 1: Verify MAXSIZE limit enforcement
+        let _: () = con
+            .xgroup_create_mkstream(STREAM_NAME, "group", "$")
+            .unwrap();
+        assert_eq!(
+            con.xcfgset(
+                STREAM_NAME,
+                &StreamConfigOptions::with_maxsize(IDMP_MAXSIZE_LIMIT).unwrap()
+            )
+            .unwrap(),
+            "OK"
+        );
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.idmp_maxsize, IDMP_MAXSIZE_LIMIT);
+
+        // Add messages up to IDMP_MAXSIZE_LIMIT (2 IIDs).
+        let opts1 = StreamAddOptions::default().idmp(PID_1, IID_1);
+        let id1: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts1)
+            .unwrap();
+        assert!(id1.is_some());
+
+        let opts2 = StreamAddOptions::default().idmp(PID_1, IID_2);
+        let id2: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[1], &opts2)
+            .unwrap();
+        assert!(id2.is_some());
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.pids_tracked, 1);
+        assert_eq!(info.iids_tracked, 2);
+        assert_eq!(info.iids_added, 2);
+        assert_eq!(info.idmp_maxsize, IDMP_MAXSIZE_LIMIT);
+
+        // Add a third IID, which should evict the oldest one (IID_1) due to LRU behavior.
+        let opts3 = StreamAddOptions::default().idmp(PID_1, IID_3);
+        let id3: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", EXTRA_FIELD_VALUE, &opts3)
+            .unwrap();
+        assert!(id3.is_some());
+
+        // Verify that the IDMP map is still tracking exactly IDMP_MAXSIZE_LIMIT IIDs.
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.iids_tracked, IDMP_MAXSIZE_LIMIT as usize);
+        assert_eq!(info.iids_added, 3);
+
+        // Now IID_1 should NOT be detected as duplicate as it was evicted.
+        let id4: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts1)
+            .unwrap();
+        assert!(id4.is_some());
+        assert_ne!(id1, id4);
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.iids_added, 4);
+        assert_eq!(info.iids_duplicates, 0);
+
+        // IID_3 should still be detected as a duplicate.
+        let id5: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", EXTRA_FIELD_VALUE, &opts3)
+            .unwrap();
+        assert!(id5.is_some());
+        assert_eq!(id3, id5);
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.iids_duplicates, 1);
+
+        // Test 2: Verify duration-based expiry
+        // Recreate the stream with short idempotency duration.
+        let _: usize = con.del(STREAM_NAME).unwrap();
+        let _: () = con
+            .xgroup_create_mkstream(STREAM_NAME, "group", "$")
+            .unwrap();
+        assert_eq!(
+            con.xcfgset(
+                STREAM_NAME,
+                &StreamConfigOptions::with_duration(IDMP_SHORT_DURATION).unwrap()
+            )
+            .unwrap(),
+            "OK"
+        );
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.idmp_duration, IDMP_SHORT_DURATION);
+
+        // Add an idempotent message.
+        let opts = StreamAddOptions::default().idmp(PID_1, IID_1);
+        let id1: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts)
+            .unwrap();
+        assert!(id1.is_some());
+
+        // Immediately try to duplicate it, which should result in deduplication and the original ID being returned.
+        let id2: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts)
+            .unwrap();
+        assert!(id2.is_some());
+        assert_eq!(id1, id2);
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(info.iids_duplicates, 1);
+
+        // Wait for the idempotency duration to expire.
+        std::thread::sleep(std::time::Duration::from_secs(
+            (IDMP_SHORT_DURATION as u64) + 1,
+        ));
+
+        // After expiry, the same message should NOT be detected as duplicate.
+        let id3: Option<String> = con
+            .xadd_options(STREAM_NAME, "*", FIELD_VALUES[0], &opts)
+            .unwrap();
+        assert!(id3.is_some());
+        assert_ne!(id1, id3);
+
+        let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
+        // The IID should be tracked again (re-added after expiry).
+        assert_eq!(info.iids_tracked, 1);
+        assert_eq!(
+            info.iids_added, 2,
+            "Should have added 2 unique messages (original + after expiry)"
+        );
+        assert_eq!(
+            info.iids_duplicates, 1,
+            "Duplicate counter should remain at 1"
+        );
+    }
 }

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -2704,7 +2704,7 @@ mod idempotency_tests {
         // Trying to configure a non-existent stream should return an error.
         let result: redis::RedisResult<String> = con.xcfgset(
             STREAM_NAME,
-            &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap(),
+            &StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION).unwrap(),
         );
         assert!(result.is_err());
         if let Err(e) = result {
@@ -2715,7 +2715,7 @@ mod idempotency_tests {
         assert_eq!(con.set(KEY_VALUE.0, KEY_VALUE.1), Ok(()));
         let result: redis::RedisResult<String> = con.xcfgset(
             KEY_VALUE.0,
-            &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap(),
+            &StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION).unwrap(),
         );
         assert!(result.is_err());
         if let Err(e) = result {
@@ -2735,7 +2735,7 @@ mod idempotency_tests {
         assert_eq!(
             con.xcfgset(
                 STREAM_NAME,
-                &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap()
+                &StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION).unwrap()
             )
             .unwrap(),
             "OK"
@@ -2749,7 +2749,7 @@ mod idempotency_tests {
         assert_eq!(
             con.xcfgset(
                 STREAM_NAME,
-                &StreamConfigOptions::with_maxsize(IDMP_CUSTOM_MAXSIZE).unwrap()
+                &StreamConfigOptions::with_idempotency_maxsize(IDMP_CUSTOM_MAXSIZE).unwrap()
             )
             .unwrap(),
             "OK"
@@ -2760,9 +2760,9 @@ mod idempotency_tests {
         assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE);
 
         // Configure with both parameters, by first setting the duration and then the maxsize.
-        let opts = StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION * 2)
+        let opts = StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION * 2)
             .unwrap()
-            .maxsize(IDMP_CUSTOM_MAXSIZE * 2)
+            .idempotency_maxsize(IDMP_CUSTOM_MAXSIZE * 2)
             .unwrap();
         assert_eq!(con.xcfgset(STREAM_NAME, &opts).unwrap(), "OK");
         let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
@@ -2771,9 +2771,9 @@ mod idempotency_tests {
         assert_eq!(info.idmp_maxsize, IDMP_CUSTOM_MAXSIZE * 2);
 
         // Configure with both parameters, by first setting the maxsize and then the duration.
-        let opts = StreamConfigOptions::with_maxsize(IDMP_CUSTOM_MAXSIZE)
+        let opts = StreamConfigOptions::with_idempotency_maxsize(IDMP_CUSTOM_MAXSIZE)
             .unwrap()
-            .duration(IDMP_CUSTOM_DURATION)
+            .idempotency_seconds(IDMP_CUSTOM_DURATION)
             .unwrap();
         assert_eq!(con.xcfgset(STREAM_NAME, &opts).unwrap(), "OK");
         let info = con.xinfo_stream_with_idempotency(STREAM_NAME).unwrap();
@@ -2824,7 +2824,7 @@ mod idempotency_tests {
         assert_eq!(
             con.xcfgset(
                 STREAM_NAME,
-                &StreamConfigOptions::with_duration(IDMP_CUSTOM_DURATION).unwrap()
+                &StreamConfigOptions::with_idempotency_seconds(IDMP_CUSTOM_DURATION).unwrap()
             )
             .unwrap(),
             "OK"
@@ -2870,7 +2870,7 @@ mod idempotency_tests {
         assert_eq!(
             con.xcfgset(
                 STREAM_NAME,
-                &StreamConfigOptions::with_maxsize(IDMP_CUSTOM_MAXSIZE).unwrap()
+                &StreamConfigOptions::with_idempotency_maxsize(IDMP_CUSTOM_MAXSIZE).unwrap()
             )
             .unwrap(),
             "OK"
@@ -2906,7 +2906,7 @@ mod idempotency_tests {
         assert_eq!(
             con.xcfgset(
                 STREAM_NAME,
-                &StreamConfigOptions::with_maxsize(IDMP_MAXSIZE_LIMIT).unwrap()
+                &StreamConfigOptions::with_idempotency_maxsize(IDMP_MAXSIZE_LIMIT).unwrap()
             )
             .unwrap(),
             "OK"
@@ -2975,7 +2975,7 @@ mod idempotency_tests {
         assert_eq!(
             con.xcfgset(
                 STREAM_NAME,
-                &StreamConfigOptions::with_duration(IDMP_SHORT_DURATION).unwrap()
+                &StreamConfigOptions::with_idempotency_seconds(IDMP_SHORT_DURATION).unwrap()
             )
             .unwrap(),
             "OK"


### PR DESCRIPTION
# Redis Streams Idempotent Producers

## Overview

This implementation adds support for idempotent message production in Redis Streams, following the **Redis 8.6+** specification:
https://redis.io/docs/latest/develop/data-types/streams/idempotency/

## What is Idempotent Message Processing?

Idempotent producers prevent duplicate messages from being added to a stream when using at-least-once delivery patterns. This is essential when:

1. **Network Issues**: Producer loses connection after sending **XADD** but before receiving the reply
2. **Producer Crashes**: Producer crashes after calling **XADD** but before marking the message as delivered

Without idempotency, retrying in these scenarios results in duplicate messages. With idempotency, Redis automatically deduplicates based on producer ID (**PID**) and idempotent ID (**IID**), ensuring each unique message is stored only once.

## Features Implemented
### Extended the XADD command to support idempotency

#### 1. Updated XADD Command Syntax

The XADD command now supports idempotency parameters (`[IDMPAUTO pid | IDMP pid iid]`), and the documentation lists them in the correct order.
```
XADD key [NOMKSTREAM] [KEEPREF | DELREF | ACKED] [IDMPAUTO pid | IDMP pid iid] [<MAXLEN|MINID> [~|=] threshold [LIMIT count]] <* | ID> field value [field value ...]
```

#### 2. StreamIdempotencyMode Enum
Added a new `enum` to represent the two idempotency modes:

```rust
pub enum StreamIdempotencyMode {
    /// Manual mode: Producer provides both producer ID (pid) and idempotent ID (iid)
    Manual {
        producer_id: String,
        idempotent_id: String,
    },
    /// Automatic mode: Producer provides only producer ID, Redis generates iid from content
    Automatic {
        producer_id: String,
    },
}
```

#### 3. StreamAddOptions Extensions
Extended `StreamAddOptions` with two new builder methods:

**`idmp()` - Manual Mode**
```rust
pub fn idmp(
    mut self,
    producer_id: impl Into<String>,
    idempotent_id: impl Into<String>,
) -> Self {
    self.idempotency = Some(StreamIdempotencyMode::Manual {
        producer_id: producer_id.into(),
        idempotent_id: idempotent_id.into(),
    });
    self
}
```

Manual mode characteristics:
- Producer controls both **PID** and **IID**
- Ideal for transaction IDs, sequence numbers, or message counters
- Deterministic deduplication
- Faster (no hash calculation overhead)

**`idmpauto()` - Automatic Mode**
```rust
pub fn idmpauto(mut self, producer_id: impl Into<String>) -> Self {
    self.idempotency = Some(StreamIdempotencyMode::Automatic {
        producer_id: producer_id.into(),
    });
    self
}
```

Automatic mode characteristics:
- Producer controls **PID**, Redis generates **IID** via **XXH128** hash of message content
- Convenient for simple use cases
- Content-based deduplication (identical content = duplicate)
- Slightly slower due to hash computation

**Additional info on hashing:**
Redis uses the [XXH128](https://github.com/Cyan4973/xxHash) hash function for calculating the message digest.
`digest(field) = mix(XXH128(field-name || field-length || field-value))`
`iid = digest(message) = mix(digest(field), …)`
_mix combines xor and sum, and ensures iid is field-order-agnostic._
- The iid is not affected by the order in which the fields are processed.
- The iid binary-length is always 16 bytes.

### XCFGSET Command and XINFO STREAM Enhancements

#### 1. XCFGSET Command

Introduced the `XCFGSET` command to configure stream idempotency parameters at runtime

**Command Syntax:**
```
XCFGSET key [IDMP-DURATION idmp-duration] [IDMP-MAXSIZE idmp-maxsize]
```

#### 2. StreamConfigOptions Struct

A validated configuration struct with fluent API:

```rust
pub struct StreamConfigOptions {
    idmp_duration: Option<u32>,  // 1-86400 seconds
    idmp_maxsize: Option<u16>,   // 1-10000 IIDs per producer
}
```

**Static Constructors:**
- `with_idempotency_seconds(u32) -> Result<Self, RedisError>` - Start with idempotency duration in seconds
- `with_idempotency_maxsize(u16) -> Result<Self, RedisError>` - Start with idempotency maxsize

**Fluent Setters:**
- `.idempotency_seconds(u32) -> Result<Self, RedisError>` - Add/update idempotency duration in seconds
- `.idempotency_maxsize(u16) -> Result<Self, RedisError>` - Add/update idempotency maxsize

**Validation Constants:**
These constants are imposed by the server.
```rust
pub const IDMP_DURATION_MIN: u32 = 1;        // 1 second
pub const IDMP_DURATION_MAX: u32 = 86400;    // 24 hours
pub const IDMP_MAXSIZE_MIN: u16 = 1;         // 1 IID
pub const IDMP_MAXSIZE_MAX: u16 = 10000;     // 10000 IIDs
```

**Usage Examples:**
```rust
// Start with idempotency duration in seconds, optionally add idempotency maxsize
let opts1 = StreamConfigOptions::with_idempotency_seconds(300)?
    .idempotency_maxsize(1000)?;

// Start with idempotency maxsize, optionally add idempotency duration in seconds
let opts2 = StreamConfigOptions::with_idempotency_maxsize(500)?
    .idempotency_seconds(300)?;
```

#### 3. XINFO STREAM with idempotency

Added a new function that returns stream information along with idempotency tracking statistics:
```rust
#[cfg(feature = "streams")]
#[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
fn xinfo_stream_with_idempotency<K: ToRedisArgs>(key: K) -> (streams::StreamInfoStreamReplyWithIdempotency) {
    cmd("XINFO").arg("STREAM").arg(key).take()
}
```

Introduced a new `StreamInfoStreamReplyWithIdempotency` structure that wraps the existing `StreamInfoStreamReply` structure and extends it with six new idempotency tracking fields:

```rust
pub struct StreamInfoStreamReplyWithIdempotency {
    /// Base stream information
    pub base: StreamInfoStreamReply,
    /// Duration in seconds that idempotent IDs are retained
    pub idmp_duration: u32,
    /// Maximum number of idempotent IDs kept for each producer
    pub idmp_maxsize: u16,
    /// Number of unique producer IDs currently tracked
    pub pids_tracked: usize,
    /// Total idempotent IDs currently stored across all producers
    pub iids_tracked: usize,
    /// Lifetime counter of unique IIDs added (persists across config changes)
    pub iids_added: usize,
    /// Lifetime counter of duplicate messages detected (persists across config changes)
    pub iids_duplicates: usize,
}
```

## Key Behavioral Characteristics

### Duplicate Detection
When a duplicate message is detected (same **PID** + **IID** combination), Redis:
- Does not add a new entry to the stream and **Returns the original message ID**
- Increments the `iids_duplicates` counter

### IDMP Map Clearing
Calling `XCFGSET` with different `IDMP-DURATION` or `IDMP-MAXSIZE` values:
- **Clears all tracked PIDs and IIDs** for that stream
- Resets `pids_tracked` and `iids_tracked` to 0
- **Preserves lifetime counters** (`iids_added` and `iids_duplicates`)

## Testing:
### XADD Idempotency Tests
**Unit Tests** - Verifying that the `StreamAddOptions` struct serializes properly with the newly introduced idempotency parameters.
**Integration Tests**:
- `test_xadd_idempotency_manual_mode` - Tests manual deduplication with explicit **PID**+**IID**
- `test_xadd_idempotency_automatic_mode` - Tests content-based deduplication
- `test_xadd_idempotency_with_other_options` - Tests that idempotency works correctly with other **XADD** options (trimming and deletion policies)

### XCFGSET Configuration Tests
**Unit Tests** - Verifying that the `StreamConfigOptions`'s validation covers:
- Min/Max boundaries
- Error messages include actual constant values
- Static constructors (`with_idempotency_seconds`, `with_idempotency_maxsize`)
- Fluent setters (`.idempotency_seconds()`, `.idempotency_maxsize()`)
- Combined duration in seconds and maxsize configurations
- Edge case validation

**Integration Tests**:
- `test_xcfgset` - Basic XCFGSET functionality and configuration verification
- `test_xcfgset_with_idempotent_messages` - Verifies that calling **XCFGSET** with different configuration values clears the active IDMP (Idempotent Message Processing) map while preserving lifetime counters.
- `test_xcfgset_idempotency_behavior` - Verifies two critical idempotency behaviors: Eviction of messages when **IDMP-MAXSIZE** is reached, and automatic expiry of **IIDs** after **IDMP-DURATION** seconds.

## Documentation:
- **XADD**: https://redis.io/docs/latest/commands/xadd
- **XCFGSET**: https://redis.io/docs/latest/commands/xcfgset/
- **XINFO STREAM** (idempotency related fields): https://redis.io/docs/latest/commands/xinfo-stream/#idmp-idempotent-message-processing-fields

- Idempotency: https://redis.io/docs/latest/develop/data-types/streams/idempotency/
- Examples: https://redis.io/docs/latest/commands/xadd/#idempotent-message-processing-examples