### PR TITLE
Add support for the `COUNT` aggregator for sorted sets

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,3 +9,19 @@ status-level = "skip"
 [[profile.default.overrides]]
 filter = 'test(cluster_async::test_async_cluster_basic_failover)'
 slow-timeout = { period = "20s", terminate-after = 2 }
+
+
+[profile.tcp_tls]
+default-filter = 'not (test(test_module))'
+
+[profile.tcp]
+default-filter = 'not (test(tls) | test(test_module))'
+
+[profile.unix]
+default-filter = 'not (test(cluster) | binary(test_sentinel) | test(tls) | test(test_module))'
+
+[profile.module_bloom]
+default-filter = 'binary(test_module_bloom*)'
+
+[profile.module_json]
+default-filter = 'test(test_module_json)'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [main, 0.*.x, 1.*.x]
+    branches: [main, 0.*.x, 1.*.x, 2.*.x]
   pull_request:
-    branches: [main, 0.*.x, 1.*.x]
+    branches: [main, 0.*.x, 1.*.x, 2.*.x]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,15 +42,17 @@ jobs:
             # Skipping ValKey 8.1 as it's too similar to 8.0
             {  db-org: valkey-io, db-name: valkey, db-version: 9.0.4, json-module-version: v2.6.22, bloom-module-version: "valkey-bloom:1.0.1" },
             # Skipping ValKey 9.1 as it's too similar to 9.0
+            #
+            # KeyDB (#2203), Dragonfly (#2204), Kvrocks, ... are implicitly supported, but this support is not tested.
           ]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Cache RedisJSON
         if: matrix.config.json-module-version != '' && matrix.config.json-module-version != 'bundled'
         id: cache-redisjson
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             /tmp/librejson.so
@@ -74,15 +76,15 @@ jobs:
           cp "$HOME/db/redisbloom.so" "$REDISRS_REDIS_BLOOM_PATH"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain/@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2.82.10
         with:
           tool: nextest
 
@@ -91,7 +93,7 @@ jobs:
 
       - name: Checkout RedisJSON
         if: steps.cache-redisjson.outputs.cache-hit != 'true' && matrix.config.json-module-version != '' && matrix.config.json-module-version != 'bundled'
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "RedisJSON/RedisJSON"
           path: "./__ci/redis-json"
@@ -155,7 +157,7 @@ jobs:
       - name: Load Valkey Bloom module from cache
         if: startsWith(matrix.config.bloom-module-version, 'valkey-bloom:')
         id: cache-valkey-bloom
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             /tmp/valkey-bloom/target/release/libvalkey_bloom.so
@@ -190,7 +192,7 @@ jobs:
       - name: Cache RedisJSON
         if: matrix.config.json-module-version != '' && matrix.config.json-module-version != 'bundled'
         id: cache-redisjson-save
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.REDISRS_REDIS_JSON_PATH }}
           key: ${{ runner.os }}-redisjson-${{ matrix.config.json-module-version }}
@@ -204,7 +206,7 @@ jobs:
       matrix: *db-matrix
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install DB
         uses: ./.github/actions/install-db
@@ -216,7 +218,7 @@ jobs:
       - name: Load Valkey Bloom module from cache
         if: startsWith(matrix.config.bloom-module-version, 'valkey-bloom:')
         id: cache-valkey-bloom
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             /tmp/valkey-bloom/target/release/libvalkey_bloom.so
@@ -233,11 +235,11 @@ jobs:
           cp "$HOME/db/redisbloom.so" "$REDISRS_REDIS_BLOOM_PATH"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain/@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
       - name: Start Redis
         run: |
@@ -288,7 +290,7 @@ jobs:
           {toolchain: 1.88.0},
         ]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: lint
         uses: ./.github/actions/lint-and-check
         with:
@@ -323,7 +325,7 @@ jobs:
           RUSTFLAGS: --cfg tokio_unstable
 
       - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
         with:
           package: redis
 
@@ -334,7 +336,7 @@ jobs:
     env:
       rust_ver: stable
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install DB
         uses: ./.github/actions/install-db
@@ -344,11 +346,11 @@ jobs:
           db-version: 8.0.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain/@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ env.rust_ver }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
       - name: Benchmark
         run: |
@@ -360,17 +362,17 @@ jobs:
           critcmp base changes
 
       # We check out again, because we switched branches in the last step.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
   flag-frenzy:
     needs: [lint, build-and-test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain/@master
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
 
       - run: |
           cargo install --git https://github.com/nihohit/flag-frenzy.git
@@ -381,7 +383,7 @@ jobs:
     runs-on: windows-2022  # Locked to `2022` because of #2124
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install OpenSSL
         shell: powershell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.3.0"
+version = "2.0.0-rc.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "redis-test"
-version = "1.0.4"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "futures",

--- a/Makefile
+++ b/Makefile
@@ -10,32 +10,32 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP without features"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --no-default-features --profile tcp
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP2"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile tcp
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and RESP3"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run --locked -p redis --all-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run --locked -p redis --all-features --profile tcp
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with all features and Rustls support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile tcp_tls
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP with native-TLS support"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,smol-native-tls-comp,connection-manager,cluster-async -E 'not test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp+tls RUST_BACKTRACE=1 cargo nextest run --locked -p redis --features=json,tokio-native-tls-comp,smol-native-tls-comp,connection-manager,cluster-async --profile tcp_tls
 
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features -E 'not (test(test_module) | test(cluster))'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=unix RUST_BACKTRACE=1 cargo nextest run --locked -p redis --all-features --profile unix
 
 	@echo "===================================================================="
 	@echo "Testing redis-test"
@@ -46,23 +46,23 @@ test-module-json:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --test test_module_json
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_json
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisJSON module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --test test_module_json
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --profile module_json
 
 test-module-bloom:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --test test_module_bloom
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features --profile module_bloom
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with RedisBloom module"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --test test_module_bloom
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features --profile module_bloom
 
 test-modules: test-module-json test-module-bloom
 

--- a/redis-test/Cargo.toml
+++ b/redis-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-test"
-version = "1.0.4"
+version = "2.0.0"
 edition = "2024"
 description = "Testing helpers for the `redis` crate"
 homepage = "https://github.com/redis-rs/redis-rs"
@@ -13,7 +13,7 @@ rust-version = "1.88"
 bench = false
 
 [dependencies]
-redis = { version = "1", path = "../redis", default-features = false }
+redis = { version = "2.0.0-rc.1", path = "../redis", default-features = false }
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
 tempfile = "3.27.0"
@@ -24,7 +24,7 @@ rand = "0.10"
 aio = ["futures", "redis/aio"]
 
 [dev-dependencies]
-redis = { version = "1", path = "../redis", features = [
+redis = { version = "2.0.0-rc.1", path = "../redis", features = [
     "aio",
     "tokio-comp",
 ] }

--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -171,7 +171,7 @@ impl RedisCluster {
         let max_attempts = 5;
 
         let mut make_server = |port| {
-            RedisServer::new_with_addr_tls_modules_and_spawner(
+            RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
                 ClusterType::build_addr(port),
                 None,
                 tls_paths.clone(),
@@ -210,7 +210,6 @@ impl RedisCluster {
                     }
                     cmd.current_dir(tempdir.path());
                     folders.push(tempdir);
-                    cmd.spawn().unwrap()
                 },
             )
         };

--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -190,22 +190,17 @@ impl RedisCluster {
                         Self::password()
                     );
                     std::fs::write(&acl_path, acl_content).expect("failed to write acl file");
-                    cmd.arg("--cluster-enabled")
-                        .arg("yes")
-                        .arg("--cluster-config-file")
-                        .arg(tempdir.path().join("nodes.conf"))
-                        .arg("--cluster-node-timeout")
-                        .arg("5000")
-                        .arg("--aclfile")
-                        .arg(&acl_path);
+                    cmd.arg2("--cluster-enabled", "yes")
+                        .arg2("--cluster-config-file", tempdir.path().join("nodes.conf"))
+                        .arg2("--cluster-node-timeout", "5000")
+                        .arg2("--aclfile", &acl_path);
                     if let Some(num_databases) = cluster_databases {
-                        cmd.arg("--cluster-databases")
-                            .arg(num_databases.to_string());
+                        cmd.arg2("--cluster-databases", num_databases.to_string());
                     }
                     if is_tls {
-                        cmd.arg("--tls-cluster").arg("yes");
+                        cmd.arg2("--tls-cluster", "yes");
                         if replicas > 0 {
-                            cmd.arg("--tls-replication").arg("yes");
+                            cmd.arg2("--tls-replication", "yes");
                         }
                     }
                     cmd.current_dir(tempdir.path());

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -123,10 +123,9 @@ const MTLS_NOT_ENABLED: bool = false;
 fn get_addr(port: u16) -> ConnectionAddr {
     let addr = RedisServer::get_addr(port);
     if let ConnectionAddr::Unix(_) = addr {
-        ConnectionAddr::Tcp(String::from("127.0.0.1"), port)
-    } else {
-        addr
+        panic!("Sentinels are not supported on unix sockets");
     }
+    addr
 }
 
 fn spawn_master_server(

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -134,7 +134,7 @@ fn spawn_master_server(
     tlspaths: &TlsFilePaths,
     modules: &[Module],
 ) -> RedisServer {
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
         get_addr(port),
         None,
         Some(tlspaths.clone()),
@@ -148,7 +148,6 @@ fn spawn_master_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }
@@ -163,7 +162,7 @@ fn spawn_replica_server(
     let config_file_path = dir.path().join("redis_config.conf");
     File::create(&config_file_path).unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),
@@ -178,7 +177,6 @@ fn spawn_replica_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }
@@ -200,7 +198,7 @@ fn spawn_sentinel_server(
     }
     file.flush().unwrap();
 
-    RedisServer::new_with_addr_tls_modules_and_spawner(
+    RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
         get_addr(port),
         Some(&config_file_path),
         Some(tlspaths.clone()),
@@ -213,7 +211,6 @@ fn spawn_sentinel_server(
                 cmd.arg("--tls-replication").arg("yes");
             }
             cmd.current_dir(dir.path());
-            cmd.spawn().unwrap()
         },
     )
 }

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -143,9 +143,9 @@ fn spawn_master_server(
         modules,
         |cmd| {
             // Minimize startup delay
-            cmd.arg("--repl-diskless-sync-delay").arg("0");
+            cmd.arg2("--repl-diskless-sync-delay", "0");
             if let ConnectionAddr::TcpTls { .. } = get_addr(port) {
-                cmd.arg("--tls-replication").arg("yes");
+                cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
         },
@@ -170,11 +170,9 @@ fn spawn_replica_server(
         None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
-            cmd.arg("--replicaof")
-                .arg("127.0.0.1")
-                .arg(master_port.to_string());
+            cmd.arg3("--replicaof", "127.0.0.1", master_port.to_string());
             if let ConnectionAddr::TcpTls { .. } = get_addr(port) {
-                cmd.arg("--tls-replication").arg("yes");
+                cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
         },
@@ -208,7 +206,7 @@ fn spawn_sentinel_server(
         |cmd| {
             cmd.arg("--sentinel");
             if let ConnectionAddr::TcpTls { .. } = get_addr(port) {
-                cmd.arg("--tls-replication").arg("yes");
+                cmd.arg2("--tls-replication", "yes");
             }
             cmd.current_dir(dir.path());
         },

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -1,7 +1,7 @@
 use redis::{ConnectionAddr, IntoConnectionInfo, ProtocolVersion, RedisConnectionInfo};
+use std::ffi::OsStr;
 use std::path::Path;
 use std::{env, fs, path::PathBuf, process};
-
 use tempfile::TempDir;
 
 use crate::utils::{TlsFilePaths, build_keys_and_certs_for_tls, get_random_available_port};
@@ -129,17 +129,14 @@ impl RedisServer {
         let redis_port = get_random_available_port();
         let addr = RedisServer::get_addr(redis_port);
 
-        RedisServer::new_with_addr_tls_modules_and_spawner(
+        RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
             addr,
             None,
             None,
             mtls_enabled,
             None,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         )
     }
 
@@ -148,33 +145,27 @@ impl RedisServer {
         modules: &[Module],
         mtls_enabled: bool,
     ) -> RedisServer {
-        RedisServer::new_with_addr_tls_modules_and_spawner(
+        RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
             addr,
             None,
             None,
             mtls_enabled,
             None,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         )
     }
 
-    pub fn new_with_addr_tls_modules_and_spawner<
-        F: FnOnce(&mut process::Command) -> process::Child,
-    >(
+    pub fn new_with_addr_tls_modules_and_cmd_refiner(
         mut addr: redis::ConnectionAddr,
         config_file: Option<&Path>,
         mut tls_paths: Option<TlsFilePaths>,
         mtls_enabled: bool,
         cert_auth_field: Option<&str>,
         modules: &[Module],
-        spawner: F,
+        cmd_refiner: impl FnOnce(&mut RedisServerCommand),
     ) -> RedisServer {
-        let bin = env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-        let mut redis_cmd = process::Command::new(&bin);
+        let mut redis_cmd = RedisServerCommand::new();
 
         if let Some(config_path) = config_file {
             redis_cmd.arg(config_path);
@@ -219,18 +210,16 @@ impl RedisServer {
             };
         }
 
-        redis_cmd
-            .stdout(process::Stdio::piped())
-            .stderr(process::Stdio::piped());
         let tempdir = tempfile::Builder::new()
             .prefix("redis")
             .tempdir()
             .expect("failed to create tempdir");
         let log_file = Self::log_file(&tempdir);
         redis_cmd.arg("--logfile").arg(log_file.clone());
-        if get_major_version(&bin) > 6 {
+        if get_major_version() > 6 {
             redis_cmd.arg("--enable-debug-command").arg("yes");
         }
+
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd
@@ -289,8 +278,10 @@ impl RedisServer {
             _ => panic!("Unknown address format: {addr:?}"),
         };
 
+        cmd_refiner(&mut redis_cmd);
+
         RedisServer {
-            process: spawner(&mut redis_cmd),
+            process: redis_cmd.spawn(),
             log_file,
             tempdir,
             addr,
@@ -331,11 +322,65 @@ impl RedisServer {
     }
 }
 
-fn get_major_version(server_binary: &str) -> u8 {
+pub struct RedisServerCommand {
+    // The actual command to run
+    cmd: process::Command,
+}
+
+impl Default for RedisServerCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RedisServerCommand {
+    pub fn new() -> Self {
+        let bin = env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
+
+        // Build the main command
+        let mut cmd = process::Command::new(&bin);
+
+        // Capture the command's stdout and stderr
+        cmd.stdout(process::Stdio::piped());
+        cmd.stderr(process::Stdio::piped());
+
+        // Build the instance
+        Self { cmd }
+    }
+
+    /// Appends a new argument to the command
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.cmd.arg(arg);
+        self
+    }
+
+    /// Set the directory to run the command in
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.cmd.current_dir(dir);
+        self
+    }
+
+    /// Runs the command
+    ///
+    /// # Panics
+    ///
+    /// This method panics if spawning fails.
+    ///
+    /// If the command itself exits (immediately or not, regardless of the exit code) this function
+    /// does _not_ panic but returns the `Child` instance.
+    pub fn spawn(&mut self) -> process::Child {
+        self.cmd
+            .spawn()
+            .unwrap_or_else(|err| panic!("Failed to run {:?}: {err}", self.cmd))
+    }
+}
+
+fn get_major_version() -> u8 {
     let full_string = String::from_utf8(
-        process::Command::new(server_binary)
+        RedisServerCommand::new()
             .arg("-v")
-            .output()
+            .spawn()
+            .wait_with_output()
             .unwrap()
             .stdout,
     )

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -175,40 +175,7 @@ impl RedisServer {
         // This stops littering `dump.rdb` files during testing/development.
         redis_cmd.arg2("--save", "");
 
-        // Load Redis Modules
-        for module in modules {
-            match module {
-                Module::Json => {
-                    // Try to pick up json module path from REDISRS_REDIS_JSON_PATH environment variable
-                    let path = match env::var("REDISRS_REDIS_JSON_PATH") {
-                        Ok(path) => path,
-                        // Falling back to legacy REDIS_RS_REDIS_JSON_PATH environment variable
-                        Err(_) => match env::var("REDIS_RS_REDIS_JSON_PATH") {
-                            Ok(path) => {
-                                eprintln!(
-                                    "Warning: Use of REDIS_RS_REDIS_JSON_PATH is deprecated. Use REDISRS_REDIS_JSON_PATH (no '_' before 'RS') instead"
-                                );
-                                path
-                            }
-                            Err(_) => {
-                                panic!(
-                                    "Unable to find path to RedisJSON at REDISRS_REDIS_JSON_PATH, is it set?"
-                                );
-                            }
-                        },
-                    };
-
-                    redis_cmd.arg2("--loadmodule", path);
-                }
-                Module::Bloom => {
-                    let path = env::var("REDISRS_REDIS_BLOOM_PATH").expect(
-                        "Unable to find path to RedisBloom at REDISRS_REDIS_BLOOM_PATH, is it set?",
-                    );
-
-                    redis_cmd.arg2("--loadmodule", path);
-                }
-            };
-        }
+        redis_cmd.load_modules(modules);
 
         let tempdir = tempfile::Builder::new()
             .prefix("redis")
@@ -404,6 +371,50 @@ impl RedisServerCommand {
         self.cmd
             .spawn()
             .unwrap_or_else(|err| panic!("Failed to run {:?}: {err}", self.cmd))
+    }
+
+    /// Loads a module from the given path
+    fn load_module(&mut self, path: String) {
+        self.arg2("--loadmodule", path);
+    }
+
+    /// Loads the given modules
+    ///
+    /// The paths to the modules are inferred from environment variables.
+    pub(crate) fn load_modules(&mut self, modules: &[Module]) {
+        for module in modules {
+            match module {
+                Module::Json => {
+                    // Try to pick up json module path from REDISRS_REDIS_JSON_PATH environment variable
+                    let path = match env::var("REDISRS_REDIS_JSON_PATH") {
+                        Ok(path) => path,
+                        // Falling back to legacy REDIS_RS_REDIS_JSON_PATH environment variable
+                        Err(_) => match env::var("REDIS_RS_REDIS_JSON_PATH") {
+                            Ok(path) => {
+                                eprintln!(
+                                    "Warning: Use of REDIS_RS_REDIS_JSON_PATH is deprecated. Use REDISRS_REDIS_JSON_PATH (no '_' before 'RS') instead"
+                                );
+                                path
+                            }
+                            Err(_) => {
+                                panic!(
+                                    "Unable to find path to RedisJSON at REDISRS_REDIS_JSON_PATH, is it set?"
+                                );
+                            }
+                        },
+                    };
+
+                    self.load_module(path);
+                }
+                Module::Bloom => {
+                    let path = env::var("REDISRS_REDIS_BLOOM_PATH").expect(
+                        "Unable to find path to RedisBloom at REDISRS_REDIS_BLOOM_PATH, is it set?",
+                    );
+
+                    self.load_module(path);
+                }
+            };
+        }
     }
 }
 

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -165,9 +165,9 @@ impl RedisServer {
     pub fn new_with_addr_tls_modules_and_spawner<
         F: FnOnce(&mut process::Command) -> process::Child,
     >(
-        addr: redis::ConnectionAddr,
+        mut addr: redis::ConnectionAddr,
         config_file: Option<&Path>,
-        tls_paths: Option<TlsFilePaths>,
+        mut tls_paths: Option<TlsFilePaths>,
         mtls_enabled: bool,
         cert_auth_field: Option<&str>,
         modules: &[Module],
@@ -238,17 +238,10 @@ impl RedisServer {
                     .arg(server_port.to_string())
                     .arg("--bind")
                     .arg(bind);
-
-                RedisServer {
-                    process: spawner(&mut redis_cmd),
-                    log_file,
-                    tempdir,
-                    addr,
-                    tls_paths: None,
-                }
             }
             redis::ConnectionAddr::TcpTls { ref host, port, .. } => {
-                let tls_paths = tls_paths.unwrap_or_else(|| build_keys_and_certs_for_tls(&tempdir));
+                let tls_paths =
+                    tls_paths.get_or_insert_with(|| build_keys_and_certs_for_tls(&tempdir));
 
                 let auth_client = if mtls_enabled { "yes" } else { "no" };
 
@@ -279,20 +272,12 @@ impl RedisServer {
                 // Insecure only disabled if `mtls` is enabled
                 let insecure = !mtls_enabled;
 
-                let addr = redis::ConnectionAddr::TcpTls {
+                addr = redis::ConnectionAddr::TcpTls {
                     host: host.clone(),
                     port,
                     insecure,
                     tls_params: None,
                 };
-
-                RedisServer {
-                    process: spawner(&mut redis_cmd),
-                    log_file,
-                    tempdir,
-                    addr,
-                    tls_paths: Some(tls_paths),
-                }
             }
             redis::ConnectionAddr::Unix(ref path) => {
                 redis_cmd
@@ -300,15 +285,16 @@ impl RedisServer {
                     .arg("0")
                     .arg("--unixsocket")
                     .arg(path);
-                RedisServer {
-                    process: spawner(&mut redis_cmd),
-                    log_file,
-                    tempdir,
-                    addr,
-                    tls_paths: None,
-                }
             }
             _ => panic!("Unknown address format: {addr:?}"),
+        };
+
+        RedisServer {
+            process: spawner(&mut redis_cmd),
+            log_file,
+            tempdir,
+            addr,
+            tls_paths,
         }
     }
 

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -173,7 +173,7 @@ impl RedisServer {
 
         // Disable snapshotting
         // This stops littering `dump.rdb` files during testing/development.
-        redis_cmd.arg("--save").arg("");
+        redis_cmd.arg2("--save", "");
 
         // Load Redis Modules
         for module in modules {
@@ -198,14 +198,14 @@ impl RedisServer {
                         },
                     };
 
-                    redis_cmd.arg("--loadmodule").arg(path);
+                    redis_cmd.arg2("--loadmodule", path);
                 }
                 Module::Bloom => {
                     let path = env::var("REDISRS_REDIS_BLOOM_PATH").expect(
                         "Unable to find path to RedisBloom at REDISRS_REDIS_BLOOM_PATH, is it set?",
                     );
 
-                    redis_cmd.arg("--loadmodule").arg(path);
+                    redis_cmd.arg2("--loadmodule", path);
                 }
             };
         }
@@ -215,18 +215,16 @@ impl RedisServer {
             .tempdir()
             .expect("failed to create tempdir");
         let log_file = Self::log_file(&tempdir);
-        redis_cmd.arg("--logfile").arg(log_file.clone());
+        redis_cmd.arg2("--logfile", log_file.clone());
         if get_major_version() > 6 {
-            redis_cmd.arg("--enable-debug-command").arg("yes");
+            redis_cmd.arg2("--enable-debug-command", "yes");
         }
 
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd
-                    .arg("--port")
-                    .arg(server_port.to_string())
-                    .arg("--bind")
-                    .arg(bind);
+                    .arg2("--port", server_port.to_string())
+                    .arg2("--bind", bind);
             }
             redis::ConnectionAddr::TcpTls { ref host, port, .. } => {
                 let tls_paths =
@@ -236,26 +234,19 @@ impl RedisServer {
 
                 // prepare redis with TLS
                 redis_cmd
-                    .arg("--tls-port")
-                    .arg(port.to_string())
-                    .arg("--port")
-                    .arg("0")
-                    .arg("--tls-cert-file")
-                    .arg(&tls_paths.redis_crt)
-                    .arg("--tls-key-file")
-                    .arg(&tls_paths.redis_key)
-                    .arg("--tls-ca-cert-file")
-                    .arg(&tls_paths.ca_crt)
-                    .arg("--tls-auth-clients")
-                    .arg(auth_client)
-                    .arg("--bind")
-                    .arg(host);
+                    .arg2("--tls-port", port.to_string())
+                    .arg2("--port", "0")
+                    .arg2("--tls-cert-file", &tls_paths.redis_crt)
+                    .arg2("--tls-key-file", &tls_paths.redis_key)
+                    .arg2("--tls-ca-cert-file", &tls_paths.ca_crt)
+                    .arg2("--tls-auth-clients", auth_client)
+                    .arg2("--bind", host);
 
                 // Enable certificate-based authentication (Redis 8.6+)
                 // The cert_auth_field specifies which certificate field to use for username mapping
                 // (e.g., "CN" for Common Name)
                 if let Some(field) = cert_auth_field {
-                    redis_cmd.arg("--tls-auth-clients-user").arg(field);
+                    redis_cmd.arg2("--tls-auth-clients-user", field);
                 }
 
                 // Insecure only disabled if `mtls` is enabled
@@ -269,11 +260,7 @@ impl RedisServer {
                 };
             }
             redis::ConnectionAddr::Unix(ref path) => {
-                redis_cmd
-                    .arg("--port")
-                    .arg("0")
-                    .arg("--unixsocket")
-                    .arg(path);
+                redis_cmd.arg2("--port", "0").arg2("--unixsocket", path);
             }
             _ => panic!("Unknown address format: {addr:?}"),
         };
@@ -351,6 +338,51 @@ impl RedisServerCommand {
     /// Appends a new argument to the command
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
         self.cmd.arg(arg);
+        self
+    }
+
+    /// Appends two new arguments to the command
+    ///
+    /// This method is purely convenience to get more readable argument setting as it allows to
+    /// re-write
+    ///
+    /// ```rust,no_run
+    /// # use redis_test::server::RedisServerCommand;
+    /// # let mut redis_cmd = RedisServerCommand::new();
+    /// redis_cmd
+    ///     .arg("--foo")
+    ///     .arg("some-value-for-foo")
+    ///     .arg("--bar")
+    ///     .arg("some-value-for-bar")
+    ///     .arg("--baz")
+    ///     .arg("some-value-for-baz");
+    /// ```
+    ///
+    /// in a more readable fashion:
+    ///
+    /// ```rust,no_run
+    /// # use redis_test::server::RedisServerCommand;
+    /// # let mut redis_cmd = RedisServerCommand::new();
+    /// redis_cmd
+    ///     .arg2("--foo", "some-value-for-foo")
+    ///     .arg2("--bar", "some-value-for-bar")
+    ///     .arg2("--baz", "some-value-for-baz");
+    /// ```
+    pub fn arg2<S1: AsRef<OsStr>, S2: AsRef<OsStr>>(&mut self, arg1: S1, arg2: S2) -> &mut Self {
+        self.cmd.arg(arg1).arg(arg2);
+        self
+    }
+
+    /// Appends three new arguments to the command
+    ///
+    /// This method is purely convenience to get more readable argument setting (cf. [`arg2`](Self::arg2)).
+    pub fn arg3<S1: AsRef<OsStr>, S2: AsRef<OsStr>, S3: AsRef<OsStr>>(
+        &mut self,
+        arg1: S1,
+        arg2: S2,
+        arg3: S3,
+    ) -> &mut Self {
+        self.cmd.arg(arg1).arg(arg2).arg(arg3);
         self
     }
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis"
-version = "1.3.0"
+version = "2.0.0-rc.1"
 keywords = ["redis", "valkey", "cluster", "sentinel", "pubsub"]
 description = "Redis driver for Rust."
 homepage = "https://github.com/redis-rs/redis-rs"
@@ -46,9 +46,7 @@ futures-util = { version = "0.3.31", default-features = false, features = [
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 async-lock = { version = "3", optional = true }
-tokio = { version = "1", features = [
-  "sync",
-], optional = true }
+tokio = { version = "1", features = ["sync"], optional = true }
 
 # Only needed for the connection manager
 arc-swap = { version = "1.9.1", optional = true }

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -231,6 +231,10 @@ name = "test_tls_cert_auth"
 required-features = ["acl", "tls-rustls", "tokio-rustls-comp", "cluster"]
 
 [[bench]]
+name = "bench_pipeline_build"
+harness = false
+
+[[bench]]
 name = "bench_basic"
 harness = false
 required-features = ["tokio-comp"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -44,7 +44,7 @@ futures-util = { version = "0.3.31", default-features = false, features = [
   "sink",
 ], optional = true }
 pin-project-lite = { version = "0.2", optional = true }
-tokio-util = { version = "0.7", optional = true }
+tokio-util = { version = "0.7.5", optional = true }
 async-lock = { version = "3", optional = true }
 tokio = { version = "1", features = ["sync"], optional = true }
 

--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -214,6 +214,22 @@ fn bench_encode_integer(b: &mut Bencher) {
     });
 }
 
+fn bench_encode_set_ex(b: &mut Bencher) {
+    // `SET key val EX <secs>` — exercises the `SetExpiry` option encoder.
+    b.iter(|| {
+        let mut pipe = redis::pipe();
+
+        for _ in 0..1_000 {
+            pipe.cmd("SET")
+                .arg("session:abc123")
+                .arg("some-value")
+                .arg(redis::SetExpiry::EX(3600))
+                .ignore();
+        }
+        pipe.get_packed_pipeline()
+    });
+}
+
 fn bench_encode_pipeline(b: &mut Bencher) {
     b.iter(|| {
         let mut pipe = redis::pipe();
@@ -248,7 +264,8 @@ fn bench_encode(c: &mut Criterion) {
         .bench_function("pipeline", bench_encode_pipeline)
         .bench_function("pipeline_nested", bench_encode_pipeline_nested)
         .bench_function("integer", bench_encode_integer)
-        .bench_function("small", bench_encode_small);
+        .bench_function("small", bench_encode_small)
+        .bench_function("set_ex", bench_encode_set_ex);
     group.finish();
 }
 

--- a/redis/benches/bench_pipeline_build.rs
+++ b/redis/benches/bench_pipeline_build.rs
@@ -1,0 +1,172 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+const N: usize = 1_000;
+
+// Builds an empty pipeline with capacity pre-reserved for the expected command, argument, and
+// argument-byte counts. This is the ONE spot that differs between the old and new layouts: the
+// new layout reserves each buffer via `reserve_for_*`, while the old layout only had
+// `with_capacity(command_count)`. Keeping the bench function names identical lets criterion
+// compare them directly.
+fn preallocated_pipe(commands: usize, args: usize, data: usize) -> redis::Pipeline {
+    let mut pipe = redis::pipe();
+    pipe.reserve_for_commands(commands)
+        .reserve_for_args(args)
+        .reserve_for_data(data);
+    pipe
+}
+
+// Create and populate a pipeline with N simple commands.
+fn bench_build_pipeline(c: &mut Criterion) {
+    c.bench_function("build_pipeline", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(&pipe);
+        });
+    });
+}
+
+// Create and populate a pipeline with N multi-arg commands.
+fn bench_build_pipeline_nested(c: &mut Criterion) {
+    c.bench_function("build_pipeline_nested", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            for _ in 0..N / 5 {
+                pipe.cmd("MSET")
+                    .arg(&[
+                        ("foo1", &b"bar"[..]),
+                        ("foo2", &b"123"[..]),
+                        ("foo3", &b"1231279712"[..]),
+                        ("foo4", &b"test"[..]),
+                    ])
+                    .ignore();
+            }
+            black_box(&pipe);
+        });
+    });
+}
+
+// Write the packed command bytes for a pre-built pipeline.
+fn bench_packed_pipeline(c: &mut Criterion) {
+    let mut pipe = redis::pipe();
+    for _ in 0..N {
+        pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+    }
+    c.bench_function("packed_pipeline", |b| {
+        b.iter(|| black_box(pipe.get_packed_pipeline()));
+    });
+}
+
+// End-to-end: create, populate, and write the packed command in one go. This is the realistic
+// per-request cost, and verifies the net change is positive across both phases.
+fn bench_build_and_pack(c: &mut Criterion) {
+    c.bench_function("build_and_pack", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+// Create and populate a pipeline whose buffers were pre-allocated up front. Compared against the
+// default `build_pipeline`, this isolates the benefit of reserving capacity; compared across the
+// old/new layouts, it pits the old `with_capacity` against the new `reserve_for_*`.
+fn bench_build_pipeline_preallocated(c: &mut Criterion) {
+    c.bench_function("build_pipeline_preallocated", |b| {
+        b.iter(|| {
+            let mut pipe = preallocated_pipe(N, N * 3, N * 16);
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(&pipe);
+        });
+    });
+}
+
+// End-to-end with pre-allocated buffers: create, populate, and write the packed command.
+fn bench_build_and_pack_preallocated(c: &mut Criterion) {
+    c.bench_function("build_and_pack_preallocated", |b| {
+        b.iter(|| {
+            let mut pipe = preallocated_pipe(N, N * 3, N * 16);
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+// Write the packed command bytes for a pre-built atomic (MULTI/EXEC) pipeline.
+fn bench_packed_pipeline_atomic(c: &mut Criterion) {
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+    for _ in 0..N {
+        pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+    }
+    c.bench_function("packed_pipeline_atomic", |b| {
+        b.iter(|| black_box(pipe.get_packed_pipeline()));
+    });
+}
+
+// End-to-end for an atomic pipeline: create, populate, and write the packed command in one go.
+fn bench_build_and_pack_atomic(c: &mut Criterion) {
+    c.bench_function("build_and_pack_atomic", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            pipe.atomic();
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+// A small atomic pipeline — the realistic transaction size, where the fixed cost of the
+// MULTI/EXEC wrapper is a meaningful fraction of the work.
+const N_SMALL: usize = 5;
+
+fn bench_packed_pipeline_atomic_small(c: &mut Criterion) {
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+    for _ in 0..N_SMALL {
+        pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+    }
+    c.bench_function("packed_pipeline_atomic_small", |b| {
+        b.iter(|| black_box(pipe.get_packed_pipeline()));
+    });
+}
+
+fn bench_build_and_pack_atomic_small(c: &mut Criterion) {
+    c.bench_function("build_and_pack_atomic_small", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            pipe.atomic();
+            for _ in 0..N_SMALL {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_build_pipeline,
+    bench_build_pipeline_nested,
+    bench_build_pipeline_preallocated,
+    bench_packed_pipeline,
+    bench_build_and_pack,
+    bench_build_and_pack_preallocated,
+    bench_packed_pipeline_atomic,
+    bench_build_and_pack_atomic,
+    bench_packed_pipeline_atomic_small,
+    bench_build_and_pack_atomic_small
+);
+criterion_main!(benches);

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -46,6 +46,8 @@ pub struct ConnectionManagerConfig {
     pub(crate) cache_config: Option<crate::caching::CacheConfig>,
     pipeline_buffer_size: Option<usize>,
     concurrency_limit: Option<usize>,
+    /// Flush threshold for the outbound write buffer; see [`AsyncConnectionConfig::set_write_backpressure_boundary`].
+    write_backpressure_boundary: Option<usize>,
     /// Optional credentials provider for dynamic authentication (e.g., token-based authentication)
     #[cfg(feature = "token-based-authentication")]
     credentials_provider: Option<std::sync::Arc<dyn crate::auth::StreamingCredentialsProvider>>,
@@ -66,6 +68,7 @@ impl std::fmt::Debug for ConnectionManagerConfig {
             cache_config,
             pipeline_buffer_size,
             concurrency_limit,
+            write_backpressure_boundary,
             #[cfg(feature = "token-based-authentication")]
             credentials_provider,
         } = &self;
@@ -79,6 +82,7 @@ impl std::fmt::Debug for ConnectionManagerConfig {
             .field("resubscribe_automatically", &resubscribe_automatically)
             .field("pipeline_buffer_size", &pipeline_buffer_size)
             .field("concurrency_limit", &concurrency_limit)
+            .field("write_backpressure_boundary", &write_backpressure_boundary)
             .field(
                 "push_sender",
                 if push_sender.is_some() {
@@ -273,6 +277,15 @@ impl ConnectionManagerConfig {
         self
     }
 
+    /// Sets the flush threshold (backpressure boundary) for the outbound write buffer.
+    ///
+    /// See [`AsyncConnectionConfig::set_write_backpressure_boundary`] for full semantics.
+    /// When left unset, the connection keeps `tokio_util`'s default boundary.
+    pub fn set_write_backpressure_boundary(mut self, boundary: usize) -> Self {
+        self.write_backpressure_boundary = Some(boundary);
+        self
+    }
+
     /// Sets a credentials provider for dynamic authentication.
     ///
     /// This is useful for token-based authentication where credentials need to be
@@ -319,6 +332,7 @@ impl Default for ConnectionManagerConfig {
             cache_config: None,
             pipeline_buffer_size: None,
             concurrency_limit: None,
+            write_backpressure_boundary: None,
             #[cfg(feature = "token-based-authentication")]
             credentials_provider: None,
         }
@@ -476,6 +490,7 @@ impl ConnectionManager {
             .set_response_timeout(config.response_timeout);
         connection_config.pipeline_buffer_size = config.pipeline_buffer_size;
         connection_config.concurrency_limit = config.concurrency_limit;
+        connection_config.write_backpressure_boundary = config.write_backpressure_boundary;
 
         #[cfg(feature = "cache-aio")]
         let cache_manager = config
@@ -863,7 +878,20 @@ mod tests {
     }
 
     #[test]
-    fn test_lazy_connection_manager_with_config() {
+    fn test_connection_manager_config_write_backpressure_boundary_default() {
+        let config = ConnectionManagerConfig::new();
+        assert_eq!(config.write_backpressure_boundary, None);
+    }
+
+    #[test]
+    fn test_connection_manager_config_write_backpressure_boundary_custom() {
+        let config =
+            ConnectionManagerConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        assert_eq!(config.write_backpressure_boundary, Some(16 * 1024 * 1024));
+    }
+
+    #[tokio::test]
+    async fn test_lazy_connection_manager_with_config() {
         // Test that lazy connection manager can be created with custom config
         let client = Client::open("redis://127.0.0.1/").unwrap();
         let config = ConnectionManagerConfig::new()
@@ -872,6 +900,18 @@ mod tests {
             .set_number_of_retries(3);
         let result = ConnectionManager::new_lazy_with_config(client, config);
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_lazy_connection_manager_wires_write_backpressure_boundary() {
+        let client = Client::open("redis://127.0.0.1/").unwrap();
+        let config =
+            ConnectionManagerConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        let manager = ConnectionManager::new_lazy_with_config(client, config).unwrap();
+        assert_eq!(
+            manager.0.connection_config.write_backpressure_boundary,
+            Some(16 * 1024 * 1024)
+        );
     }
 
     #[test]

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -600,6 +600,9 @@ impl MultiplexedConnection {
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
         let mut codec = ValueCodec::default().framed(stream);
+        if let Some(boundary) = config.write_backpressure_boundary {
+            codec.set_backpressure_boundary(boundary);
+        }
         if config.push_sender.is_some() {
             check_resp3!(
                 connection_info.protocol,

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -766,7 +766,7 @@ impl MultiplexedConnection {
         };
         #[cfg(feature = "cache-aio")]
         if let Some(cache_manager) = &self.cache_manager {
-            match cache_manager.get_cached_cmd(cmd) {
+            match cache_manager.get_cached_cmd(crate::cmd::CmdRef::from_cmd(cmd)) {
                 PrepareCacheResult::Cached(value) => return Ok(value),
                 PrepareCacheResult::NotCached(cacheable_command) => {
                     let mut pipeline = crate::Pipeline::new();
@@ -778,7 +778,7 @@ impl MultiplexedConnection {
                             pipeline.get_packed_pipeline(),
                             Some(PipelineResponseExpectation {
                                 skipped_response_count: 0,
-                                expected_response_count: pipeline.commands.len(),
+                                expected_response_count: pipeline.len(),
                                 is_transaction: false,
                                 seen_responses: 0,
                             }),

--- a/redis/src/caching/cache_manager.rs
+++ b/redis/src/caching/cache_manager.rs
@@ -1,7 +1,7 @@
 use super::cmd::{CacheableCommand, CacheablePipeline, MultipleCachedCommandPart};
 use super::sharded_lru::*;
 use super::{CacheConfig, CacheMode, CacheStatistics};
-use crate::cmd::{Cmd, cmd_len};
+use crate::cmd::CmdRef;
 use crate::{FromRedisValue, Pipeline, PushKind, Value};
 use std::cmp::min;
 use std::ops::Add;
@@ -84,7 +84,7 @@ impl CacheManager {
         }
     }
 
-    pub(crate) fn get_cached_cmd<'a>(&self, cmd: &'a Cmd) -> PrepareCacheResult<'a> {
+    pub(crate) fn get_cached_cmd<'a>(&self, cmd: CmdRef<'a>) -> PrepareCacheResult<'a> {
         match self.cache_config.mode {
             CacheMode::All => self.get_cached_cmd_inner(cmd),
             CacheMode::OptIn => {
@@ -101,7 +101,7 @@ impl CacheManager {
         }
     }
 
-    fn calculate_expiration_time(&self, cmd: &Cmd) -> Instant {
+    fn calculate_expiration_time(&self, cmd: CmdRef<'_>) -> Instant {
         let client_side_ttl = cmd
             .get_cache_config()
             .as_ref()
@@ -126,7 +126,7 @@ impl CacheManager {
         }
     }
 
-    fn extract_simple_arguments<'a>(&self, cmd: &'a Cmd) -> Vec<&'a [u8]> {
+    fn extract_simple_arguments<'a>(&self, cmd: CmdRef<'a>) -> Vec<&'a [u8]> {
         cmd.args_iter()
             .skip(1) // Skip the command name
             .filter_map(|arg| match arg {
@@ -138,7 +138,7 @@ impl CacheManager {
 
     fn process_multi_key_arguments<'a>(
         &self,
-        cmd: &'a Cmd,
+        cmd: CmdRef<'a>,
         is_json_command: bool,
         single_command_name: &[u8],
         commands: &mut Vec<(usize, MultipleCachedCommandPart<'a>)>,
@@ -177,7 +177,7 @@ impl CacheManager {
 
     fn handle_multi_key_command<'a>(
         &self,
-        cmd: &'a Cmd,
+        cmd: CmdRef<'a>,
         command_name_str: &'a str,
         single_command_name: &[u8],
         client_side_expire: Instant,
@@ -212,7 +212,7 @@ impl CacheManager {
 
     fn handle_single_key_command<'a>(
         &self,
-        cmd: &'a Cmd,
+        cmd: CmdRef<'a>,
         client_side_expire: Instant,
     ) -> PrepareCacheResult<'a> {
         let redis_key = match cmd.arg_idx(1) {
@@ -220,7 +220,7 @@ impl CacheManager {
             None => return PrepareCacheResult::NotCacheable,
         };
 
-        let cmd_key = cmd.data.as_slice();
+        let cmd_key = cmd.data();
 
         if let Some(value) = self.get(redis_key, cmd_key) {
             return PrepareCacheResult::Cached(value);
@@ -241,8 +241,8 @@ impl CacheManager {
     /// If there isn't enough information in cache but Cmd is cacheable then packs enough information
     /// into CacheableCommand and returns PrepareCacheResult::NotCached.
     /// If Cmd doesn't support client side caching then it returns PrepareCacheResult::NotCacheable.
-    fn get_cached_cmd_inner<'a>(&self, cmd: &'a Cmd) -> PrepareCacheResult<'a> {
-        if cmd_len(cmd) < 2 {
+    fn get_cached_cmd_inner<'a>(&self, cmd: CmdRef<'a>) -> PrepareCacheResult<'a> {
+        if cmd.encoded_len() < 2 {
             return PrepareCacheResult::NotCacheable;
         }
 
@@ -279,10 +279,10 @@ impl CacheManager {
         let transaction_mode = requested_pipeline.transaction_mode;
         let mut packed_pipeline = Pipeline::new();
 
-        for (idx, cmd) in requested_pipeline.commands.iter().enumerate() {
-            if requested_pipeline.ignored_commands.contains(&idx) {
+        for cmd in requested_pipeline.cmd_iter() {
+            if cmd.is_ignored() {
                 commands.push(PrepareCacheResult::Ignored);
-                packed_pipeline.add_command(cmd.clone());
+                packed_pipeline.add_command_ref(cmd);
                 continue;
             }
             let cacheable_command = self.get_cached_cmd(cmd);
@@ -293,7 +293,7 @@ impl CacheManager {
                 }
                 PrepareCacheResult::NotCacheable => {
                     // It must be added to packed_pipeline manually, since it's not packed via pack_command.
-                    packed_pipeline.add_command(cmd.clone());
+                    packed_pipeline.add_command_ref(cmd);
                 }
                 // PrepareCacheResult::Ignored shouldn't return by get_cached_cmd
                 _ => panic!("Unexpected result is given from get_cached_cmd"),
@@ -303,9 +303,9 @@ impl CacheManager {
 
         let pipeline_response_counts = if transaction_mode {
             packed_pipeline.atomic();
-            (packed_pipeline.commands.len() + 1, 1)
+            (packed_pipeline.len() + 1, 1)
         } else {
-            (0, packed_pipeline.commands.len())
+            (0, packed_pipeline.len())
         };
         let cp = CacheablePipeline {
             commands,

--- a/redis/src/caching/cmd.rs
+++ b/redis/src/caching/cmd.rs
@@ -1,4 +1,4 @@
-use crate::{Cmd, ErrorKind, Pipeline, RedisError, RedisResult, Value};
+use crate::{Cmd, ErrorKind, Pipeline, RedisError, RedisResult, Value, cmd::CmdRef};
 use std::{iter::zip, time::Instant};
 
 use super::{CacheManager, CacheMode, PrepareCacheResult};
@@ -49,7 +49,7 @@ impl CacheablePipeline<'_> {
 pub(crate) struct SingleCachedCommand<'a> {
     pub(crate) redis_key: &'a [u8],
     pub(crate) cmd_key: &'a [u8],
-    pub(crate) cmd: &'a Cmd,
+    pub(crate) cmd: CmdRef<'a>,
     pub(crate) client_side_expire: Instant,
 }
 
@@ -144,7 +144,7 @@ impl CacheableCommand<'_> {
         match self {
             CacheableCommand::Single(scc) => {
                 pipeline.add_command(Cmd::pttl(scc.redis_key));
-                pipeline.add_command(scc.cmd.clone());
+                pipeline.add_command_ref(scc.cmd);
             }
             CacheableCommand::Multiple {
                 command_name,

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -195,6 +195,8 @@ pub struct AsyncConnectionConfig {
     pub(crate) dns_resolver: Option<std::sync::Arc<dyn AsyncDNSResolver>>,
     pub(crate) pipeline_buffer_size: Option<usize>,
     pub(crate) concurrency_limit: Option<usize>,
+    /// Flush threshold for the outbound write buffer; see [`AsyncConnectionConfig::set_write_backpressure_boundary`].
+    pub(crate) write_backpressure_boundary: Option<usize>,
     /// Optional credentials provider for dynamic authentication (e.g., token-based authentication)
     #[cfg(feature = "token-based-authentication")]
     pub(crate) credentials_provider: Option<std::sync::Arc<dyn StreamingCredentialsProvider>>,
@@ -212,6 +214,7 @@ impl Default for AsyncConnectionConfig {
             dns_resolver: Default::default(),
             pipeline_buffer_size: None,
             concurrency_limit: None,
+            write_backpressure_boundary: None,
             #[cfg(feature = "token-based-authentication")]
             credentials_provider: None,
         }
@@ -348,6 +351,26 @@ impl AsyncConnectionConfig {
     /// By default there is no limit.
     pub fn set_concurrency_limit(mut self, limit: usize) -> Self {
         self.concurrency_limit = Some(limit);
+        self
+    }
+
+    /// Sets the flush threshold (backpressure boundary) for the outbound write buffer.
+    ///
+    /// The multiplexed connection encodes commands into an in-memory buffer before
+    /// writing them to the socket. This value controls how many bytes may accumulate
+    /// in that buffer before the connection flushes to the socket and applies
+    /// backpressure to newly queued commands.
+    ///
+    /// With a small threshold the buffer flushes frequently and, when commands are
+    /// produced faster than the socket drains, it repeatedly grows by reallocation. A
+    /// larger threshold lets the buffer reach a stable capacity and batch larger writes,
+    /// trading a higher peak memory bound (roughly this many bytes per connection) for
+    /// fewer reallocations and syscalls. The buffer still grows lazily, so idle
+    /// connections do not hold this much memory.
+    ///
+    /// When left unset, the connection keeps `tokio_util`'s default boundary (8 KiB).
+    pub fn set_write_backpressure_boundary(mut self, boundary: usize) -> Self {
+        self.write_backpressure_boundary = Some(boundary);
         self
     }
 
@@ -693,5 +716,19 @@ mod test {
     fn test_async_connection_config_concurrency_limit_custom() {
         let config = AsyncConnectionConfig::new().set_concurrency_limit(128);
         assert_eq!(config.concurrency_limit, Some(128));
+    }
+
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_async_connection_config_write_backpressure_boundary_default() {
+        let config = AsyncConnectionConfig::new();
+        assert_eq!(config.write_backpressure_boundary, None);
+    }
+
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_async_connection_config_write_backpressure_boundary_custom() {
+        let config = AsyncConnectionConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        assert_eq!(config.write_backpressure_boundary, Some(16 * 1024 * 1024));
     }
 }

--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -708,7 +708,7 @@ where
                         if !matches!(res, Value::ServerError(_))
                             && let Some(tracker) = &self.subscription_tracker
                             && let Some((action, args)) =
-                                SubscriptionTracker::to_request(cmd.as_ref())
+                                SubscriptionTracker::to_request(cmd.as_ref().args_iter())
                         {
                             let mut tracker = tracker.lock().unwrap();
                             tracker.update_with_request(action, args);
@@ -752,7 +752,7 @@ where
                                 if matches!(res[index], Value::ServerError(_)) {
                                     None
                                 } else {
-                                    SubscriptionTracker::to_request(cmd)
+                                    SubscriptionTracker::to_request(cmd.args_iter())
                                 }
                             })
                             .peekable();

--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -135,7 +135,7 @@ use futures_util::{
     sink::Sink,
     stream::{self, Stream, StreamExt},
 };
-use log::{debug, trace, warn};
+use log::{debug, info, trace, warn};
 use rand::{rng, seq::IteratorRandom};
 use request::{CmdArg, PendingRequest, Request, RequestState, Retry};
 use routing::{InternalRoutingInfo, InternalSingleNodeRouting, route_for_pipeline};
@@ -431,7 +431,61 @@ where
     }
 }
 
-type ConnectionMap<C> = HashMap<NodeAddress, C>;
+type ConnectionMap<C> = HashMap<NodeAddress, ConnState<C>>;
+
+enum ConnState<C> {
+    // Connection has been successfully established at some point.
+    Connected(C),
+    // Connection is being repaired/reconnected. The old C is retained for faster reconnect.
+    Reconnecting(C),
+    // New connection that we are trying to connect to.
+    Connecting,
+}
+
+impl<C> ConnState<C> {
+    fn connected(&self) -> Option<C>
+    where
+        C: Clone,
+    {
+        match self {
+            ConnState::Connected(conn) => Some(conn.clone()),
+            ConnState::Reconnecting(_) | ConnState::Connecting => None,
+        }
+    }
+
+    // Get the underlying connection anyway whether it is being reconnected or not.
+    fn connected_or_reconnecting(&self) -> Option<C>
+    where
+        C: Clone,
+    {
+        match self {
+            ConnState::Connected(conn) | ConnState::Reconnecting(conn) => Some(conn.clone()),
+            ConnState::Connecting => None,
+        }
+    }
+
+    fn into_conn(self) -> Option<C> {
+        match self {
+            ConnState::Connected(conn) | ConnState::Reconnecting(conn) => Some(conn),
+            ConnState::Connecting => None,
+        }
+    }
+}
+
+fn mark_reconnecting<C>(connections: &mut ConnectionMap<C>, addr: NodeAddress) {
+    connections
+        .entry(addr.clone())
+        .and_modify(|state| {
+            *state = match std::mem::replace(state, ConnState::Connecting) {
+                ConnState::Connected(conn) => {
+                    warn!("ClusterConnInner: connection to {addr:?} lost; repairing in background");
+                    ConnState::Reconnecting(conn)
+                }
+                other => other,
+            };
+        })
+        .or_insert(ConnState::Connecting);
+}
 
 /// This is the internal representation of an async Redis Cluster connection. It stores the
 /// underlying connections maintained for each node in the cluster, as well
@@ -482,25 +536,33 @@ where
         }
         let (receivers, requests): (Vec<_>, Vec<_>) = {
             let to_request = |(addr, cmd): (&NodeAddress, Arc<Cmd>)| {
-                read_guard.0.get(addr).cloned().map(|conn| {
-                    let (sender, receiver) = oneshot::channel();
-                    let addr = addr.clone();
-                    (
-                        (addr.clone(), receiver),
-                        PendingRequest {
-                            retry: 0,
-                            sender: request::ResultExpectation::External(sender),
-                            cmd: CmdArg::Cmd {
-                                cmd,
-                                routing: InternalSingleNodeRouting::Connection {
-                                    identifier: addr,
-                                    conn,
-                                }
-                                .into(),
+                read_guard
+                    .0
+                    .get(addr)
+                    // For a fan-out, we do not want to silently return a partial response
+                    // by skipping a shard because of a connection issue.
+                    // We are intentionally using a connection under repair (Reconnecting state).
+                    // It may or may not succeed. But the aggregate response will be honest.
+                    .and_then(ConnState::connected_or_reconnecting)
+                    .map(|conn| {
+                        let (sender, receiver) = oneshot::channel();
+                        let addr = addr.clone();
+                        (
+                            (addr.clone(), receiver),
+                            PendingRequest {
+                                retry: 0,
+                                sender: request::ResultExpectation::External(sender),
+                                cmd: CmdArg::Cmd {
+                                    cmd,
+                                    routing: InternalSingleNodeRouting::Connection {
+                                        identifier: addr,
+                                        conn,
+                                    }
+                                    .into(),
+                                },
                             },
-                        },
-                    )
-                })
+                        )
+                    })
             };
             let slot_map = &read_guard.1;
 
@@ -788,67 +850,75 @@ where
         &self,
         route: InternalSingleNodeRouting<C>,
     ) -> RedisResult<(NodeAddress, C)> {
-        let read_guard = self.conn_lock.read().await;
-
-        let conn = match route {
-            InternalSingleNodeRouting::Random => None,
-            InternalSingleNodeRouting::SpecificNode(route) => read_guard
-                .1
-                .slot_addr_for_route(&route, self.routing_strategy.as_deref())
-                .cloned(),
+        let route = match route {
+            InternalSingleNodeRouting::Random => {
+                let read_guard = self.conn_lock.read().await;
+                return match get_random_connection(&read_guard.0) {
+                    Some((addr, conn)) => Ok((addr, conn)),
+                    None => {
+                        Err((ErrorKind::ClusterConnectionNotFound, "No connections found").into())
+                    }
+                };
+            }
+            InternalSingleNodeRouting::SpecificNode(route) => route,
             InternalSingleNodeRouting::Connection { identifier, conn } => {
                 return Ok((identifier, conn));
             }
             InternalSingleNodeRouting::Redirect { redirect, .. } => {
-                drop(read_guard);
                 // redirected requests shouldn't use a random connection, so they have a separate codepath.
                 return self.get_redirected_connection(redirect).await;
             }
             InternalSingleNodeRouting::ByAddress(address) => {
-                if let Some(conn) = read_guard.0.get(&address).cloned() {
-                    return Ok((address, conn));
-                } else {
-                    return Err((
+                let read_guard = self.conn_lock.read().await;
+                return match read_guard.0.get(&address).and_then(ConnState::connected) {
+                    Some(conn) => Ok((address, conn)),
+                    None => Err((
                         ErrorKind::Client,
                         "Requested connection not found",
                         address.to_string(),
                     )
-                        .into());
-                }
+                        .into()),
+                };
             }
+        };
+
+        let read_guard = self.conn_lock.read().await;
+        let preferred = read_guard
+            .1
+            .slot_addr_for_route(&route, self.routing_strategy.as_deref())
+            .cloned();
+
+        if let Some(ref addr) = preferred
+            && let Some(conn) = read_guard.0.get(addr).and_then(ConnState::connected)
+        {
+            return Ok((addr.clone(), conn));
         }
-        .map(|addr| {
-            let conn = read_guard.0.get(&addr).cloned();
-            (addr, conn)
-        });
+
+        // The preferred node is not connected (e.g. it is being repaired by the `reconnect_loop` future).
+        // Instead of erroring or waiting we try a fallback (within the same shard).
+        let fallback = read_guard
+            .1
+            .shard_fallback_addrs(&route)
+            .into_iter()
+            .find_map(|candidate| {
+                read_guard
+                    .0
+                    .get(&candidate)
+                    .and_then(ConnState::connected)
+                    .map(|conn| (candidate, conn))
+            });
         drop(read_guard);
+        if let Some(found) = fallback {
+            return Ok(found);
+        }
 
-        let addr_conn_option = match conn {
-            Some((addr, Some(conn))) => Some((addr, conn)),
-            Some((addr, None)) => self
-                .connect_check_and_add(&addr)
-                .await
-                .ok()
-                .map(|conn| (addr, conn)),
-            None => None,
-        };
+        let read_guard = self.conn_lock.read().await;
+        if let Some((random_addr, random_conn)) = get_random_connection(&read_guard.0) {
+            drop(read_guard);
+            return Ok((random_addr, random_conn));
+        }
 
-        let (addr, conn) = match addr_conn_option {
-            Some(tuple) => tuple,
-            None => {
-                let read_guard = self.conn_lock.read().await;
-                if let Some((random_addr, random_conn)) = get_random_connection(&read_guard.0) {
-                    drop(read_guard);
-                    (random_addr, random_conn)
-                } else {
-                    return Err(
-                        (ErrorKind::ClusterConnectionNotFound, "No connections found").into(),
-                    );
-                }
-            }
-        };
-
-        Ok((addr, conn))
+        Err((ErrorKind::ClusterConnectionNotFound, "No connections found").into())
     }
 
     async fn get_redirected_connection(&self, redirect: Redirect) -> RedisResult<(NodeAddress, C)> {
@@ -858,7 +928,7 @@ where
             Redirect::Ask(addr) => addr,
         };
         let read_guard = self.conn_lock.read().await;
-        let conn = read_guard.0.get(&addr).cloned();
+        let conn = read_guard.0.get(&addr).and_then(ConnState::connected);
         drop(read_guard);
         let mut conn = match conn {
             Some(conn) => conn,
@@ -877,17 +947,24 @@ where
     }
 
     async fn connect_check_and_add(&self, addr: &NodeAddress) -> RedisResult<C> {
-        match connect_and_check::<C>(addr, &self.cluster_params).await {
-            Ok(conn) => {
-                self.conn_lock
-                    .write()
-                    .await
-                    .0
-                    .insert(addr.clone(), conn.clone());
-                Ok(conn)
-            }
-            Err(err) => Err(err),
-        }
+        let conn = connect_and_check::<C>(addr, &self.cluster_params).await?;
+        self.conn_lock
+            .write()
+            .await
+            .0
+            .insert(addr.clone(), ConnState::Connected(conn.clone()));
+        Ok(conn)
+    }
+
+    async fn query_slots(conn: &mut C, addr: &NodeAddress, slots: &mut SlotMap) -> RedisResult<()> {
+        let mut slot_refresh_cmd = slot_cmd();
+        slot_refresh_cmd.skip_concurrency_limit = true;
+        let value = conn
+            .req_packed_command(&slot_refresh_cmd)
+            .await
+            .and_then(|value| value.extract_error())?;
+        let v: Vec<SlotRange> = parse_slots(value, addr.host())?;
+        build_slot_map(slots, v)
     }
 
     // Query a node to discover slot-> master mappings.
@@ -895,30 +972,60 @@ where
         let mut write_guard = self.conn_lock.write().await;
         let (connections, slots) = &mut *write_guard;
 
-        let mut result = Ok(());
-        for (addr, conn) in &mut *connections {
-            result = async {
-                let mut slot_refresh_cmd = slot_cmd();
-                slot_refresh_cmd.skip_concurrency_limit = true;
-                let value = conn
-                    .req_packed_command(&slot_refresh_cmd)
-                    .await
-                    .and_then(|value| value.extract_error())?;
-                let v: Vec<SlotRange> = parse_slots(value, addr.host())?;
-                build_slot_map(slots, v)
-            }
-            .await;
-            if result.is_ok() {
-                break;
+        let mut found = false;
+        let mut last_err = None;
+
+        // First pass is to query previously-known good connections for the new slots.
+        for (addr, state) in &mut *connections {
+            let ConnState::Connected(conn) = state else {
+                continue;
+            };
+            match Self::query_slots(conn, addr, slots).await {
+                Ok(()) => {
+                    found = true;
+                    break;
+                }
+                Err(err) => last_err = Some(err),
             }
         }
-        result?;
+
+        // Second pass is to attempt to repair connections on-demand as we iterate through each one.
+        // We include Connected connections in this pass, in addition to the first pass above,
+        // so that we can do inline connection repairs, if needed (via `get_or_create_conn`).
+        if !found {
+            for (addr, state) in &mut *connections {
+                let prev = std::mem::replace(state, ConnState::Connecting).into_conn();
+                match get_or_create_conn(addr, prev, &self.cluster_params).await {
+                    Ok(mut conn) => {
+                        let res = Self::query_slots(&mut conn, addr, slots).await;
+                        *state = ConnState::Connected(conn);
+                        match res {
+                            Ok(()) => {
+                                found = true;
+                                break;
+                            }
+                            Err(err) => last_err = Some(err),
+                        }
+                    }
+                    Err(err) => last_err = Some(err),
+                }
+            }
+        }
+
+        if !found {
+            return Err(last_err.unwrap_or_else(|| {
+                (ErrorKind::ClusterConnectionNotFound, "No connections found").into()
+            }));
+        }
 
         if let Some(ref strategy) = self.routing_strategy {
             strategy.on_topology_changed(slots.topology());
         }
 
         let nodes = slots.values().flatten().cloned().collect::<HashSet<_>>();
+
+        connections.retain(|addr, _| nodes.contains(addr));
+
         self.refresh_connections_locked(connections, nodes).await;
 
         Ok(())
@@ -930,11 +1037,10 @@ where
         nodes: HashSet<NodeAddress>,
     ) {
         let nodes_len = nodes.len();
-
         let addresses_and_connections_iter = nodes
             .into_iter()
             .map(|addr| {
-                let connection = connections.remove(&addr);
+                let connection = connections.remove(&addr).and_then(ConnState::into_conn);
                 async move {
                     let res = get_or_create_conn(&addr, connection, &self.cluster_params).await;
                     (addr, res)
@@ -946,7 +1052,7 @@ where
             .buffer_unordered(nodes_len.max(8))
             .fold(connections, |connections, (addr, result)| async move {
                 if let Ok(conn) = result {
-                    connections.insert(addr, conn);
+                    connections.insert(addr, ConnState::Connected(conn));
                 }
                 connections
             })
@@ -991,8 +1097,76 @@ struct ClusterConnInner<C> {
     state: ConnectionState,
     #[allow(clippy::complexity)]
     in_flight_requests: stream::FuturesUnordered<Pin<Box<Request<C>>>>,
+    reconnect_futures: stream::FuturesUnordered<BoxFuture<'static, ()>>,
     pending_requests_rx: mpsc::UnboundedReceiver<PendingRequest<C>>,
     refresh_error: Option<RedisError>,
+}
+
+// Keep trying to repair `addr` until it is re-connected, or the node
+// has left the topology.
+// This is a continuous attempt to reconnect rather than one-shot.
+async fn reconnect_loop<C>(core: Core<C>, addr: NodeAddress)
+where
+    C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
+{
+    {
+        let mut guard = core.conn_lock.write().await;
+        if matches!(
+            guard.0.get(&addr),
+            Some(ConnState::Reconnecting(_) | ConnState::Connecting)
+        ) {
+            return;
+        }
+        mark_reconnecting(&mut guard.0, addr.clone());
+    }
+
+    let mut backoff = Duration::from_millis(50);
+    loop {
+        let prev = {
+            let guard = core.conn_lock.read().await;
+            let in_topology = guard.1.addresses_for_all_nodes().contains(&addr);
+            let entry = guard.0.get(&addr);
+            if matches!(entry, Some(ConnState::Connected(_))) {
+                break;
+            }
+            let prev_conn = entry.and_then(ConnState::connected_or_reconnecting);
+            drop(guard);
+
+            if !in_topology {
+                core.conn_lock.write().await.0.remove(&addr);
+                break;
+            }
+            prev_conn
+        };
+
+        match get_or_create_conn(&addr, prev, &core.cluster_params).await {
+            Ok(conn) => {
+                let newly_installed = {
+                    let mut guard = core.conn_lock.write().await;
+                    if matches!(guard.0.get(&addr), Some(ConnState::Connected(_))) {
+                        false
+                    } else {
+                        guard.0.insert(addr.clone(), ConnState::Connected(conn));
+                        true
+                    }
+                };
+                if newly_installed {
+                    info!("ClusterConnInner: reconnected to {addr:?}");
+                    // TODO: make the resubscribe semantic more granular.
+                    // Right now resubscribe() re-sends every subscription across all nodes.
+                    // We should re-subscribe for the newly repaired node.
+                    core.resubscribe();
+                }
+                break;
+            }
+            Err(err) => {
+                debug!("repair_node: failed to reconnect {addr:?}: {err:?}");
+            }
+        }
+
+        boxed_sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(1));
+    }
 }
 
 fn boxed_sleep(duration: Duration) -> BoxFuture<'static, ()> {
@@ -1025,7 +1199,7 @@ struct Message<C> {
 
 enum RecoverFuture {
     RecoverSlots(BoxFuture<'static, RedisResult<()>>),
-    Reconnect(BoxFuture<'static, RedisResult<()>>),
+    ReconnectInitial(BoxFuture<'static, RedisResult<()>>),
 }
 
 enum ConnectionState {
@@ -1082,11 +1256,12 @@ where
         let mut inner = ClusterConnInner {
             inner: core.clone(),
             in_flight_requests: Default::default(),
+            reconnect_futures: Default::default(),
             pending_requests_rx,
             refresh_error: None,
             state: ConnectionState::PollComplete,
         };
-        inner.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
+        inner.state = ConnectionState::Recover(RecoverFuture::ReconnectInitial(Box::pin(
             inner.reconnect_to_initial_nodes(),
         )));
         inner
@@ -1114,7 +1289,7 @@ where
                 |(mut connections, mut error), result| async move {
                     match result {
                         Ok((addr, conn)) => {
-                            connections.insert(addr, conn);
+                            connections.insert(addr, ConnState::Connected(conn));
                         }
                         Err(err) => {
                             // Store at least one error to use as detail in the connection error if
@@ -1156,18 +1331,29 @@ where
         }
     }
 
-    fn refresh_connections(
-        &mut self,
-        addrs: HashSet<NodeAddress>,
-    ) -> impl Future<Output = ()> + use<C> {
-        let inner = self.inner.clone();
-        async move {
-            let mut write_guard = inner.conn_lock.write().await;
-
-            inner
-                .refresh_connections_locked(&mut write_guard.0, addrs)
-                .await;
+    // Create reconnecting futures and register them into `reconnect_futures`
+    // so we can poll them at the next poll_flush iteration.
+    fn register_reconnect_futures(&mut self, addrs: HashSet<NodeAddress>) {
+        // This is best-effort, non-blocking, opportunistic check to see
+        // if there is already a repair in progress.
+        // This is not load-bearing since the real dedupe logic lives inside reconnect_loop.
+        let opportunistic_read_guard = self.inner.conn_lock.try_read().ok();
+        for addr in addrs {
+            if let Some(guard) = &opportunistic_read_guard
+                && matches!(
+                    guard.0.get(&addr),
+                    Some(ConnState::Reconnecting(_) | ConnState::Connecting)
+                )
+            {
+                continue;
+            }
+            self.reconnect_futures
+                .push(Box::pin(reconnect_loop(self.inner.clone(), addr)));
         }
+    }
+
+    fn poll_reconnects(&mut self, cx: &mut task::Context<'_>) {
+        while let Poll::Ready(Some(())) = Pin::new(&mut self.reconnect_futures).poll_next(cx) {}
     }
 
     async fn wait_for_initial_connection(&mut self) -> RedisResult<()> {
@@ -1176,7 +1362,7 @@ where
         {
             match fut {
                 RecoverFuture::RecoverSlots(fut) => fut.await?,
-                RecoverFuture::Reconnect(fut) => fut.await?,
+                RecoverFuture::ReconnectInitial(fut) => fut.await?,
             }
         }
         Ok(())
@@ -1200,7 +1386,7 @@ where
                     Err(err)
                 }
             },
-            RecoverFuture::Reconnect(future) => {
+            RecoverFuture::ReconnectInitial(future) => {
                 match ready!(future.as_mut().poll(cx)) {
                     Err(err) => warn!("Can't reconnect to initial nodes: `{err}`"),
                     Ok(()) => trace!("Reconnected connections"),
@@ -1247,9 +1433,7 @@ where
         }
     }
 
-    fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
-        let mut poll_flush_action = PollFlushAction::None;
-
+    fn dispatch_pending(&mut self) {
         loop {
             let request = match self.pending_requests_rx.try_recv() {
                 Ok(request) => request,
@@ -1271,6 +1455,10 @@ where
                 future: RequestState::Future { future },
             }));
         }
+    }
+
+    fn poll_in_flight(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
+        let mut poll_flush_action = PollFlushAction::None;
 
         loop {
             let (request_handling, next) =
@@ -1289,6 +1477,11 @@ where
         } else {
             Poll::Pending
         }
+    }
+
+    fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
+        self.dispatch_pending();
+        self.poll_in_flight(cx)
     }
 
     fn send_refresh_error(&mut self) {
@@ -1402,11 +1595,9 @@ where
         trace!("poll_flush: {:?}", self.state);
         loop {
             self.send_refresh_error();
+            self.poll_reconnects(cx);
 
             if let Err(err) = ready!(self.as_mut().poll_recover(cx)) {
-                // We failed to reconnect, while we will try again we will report the
-                // error if we can to avoid getting trapped in an infinite loop of
-                // trying to reconnect
                 self.refresh_error = Some(err);
 
                 // Give other tasks a chance to progress before we try to recover
@@ -1424,14 +1615,12 @@ where
                     )));
                 }
                 PollFlushAction::Reconnect(addrs) => {
-                    self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
-                        self.refresh_connections(addrs).map(Ok),
-                    )));
+                    self.register_reconnect_futures(addrs);
                 }
                 PollFlushAction::ReconnectFromInitialConnections => {
-                    self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
-                        self.reconnect_to_initial_nodes(),
-                    )));
+                    self.state = ConnectionState::Recover(RecoverFuture::ReconnectInitial(
+                        Box::pin(self.reconnect_to_initial_nodes()),
+                    ));
                 }
             }
         }
@@ -1536,6 +1725,9 @@ where
     if let Some(limit) = params.connection_concurrency_limit {
         config = config.set_concurrency_limit(limit);
     }
+    if let Some(boundary) = params.write_backpressure_boundary {
+        config = config.set_write_backpressure_boundary(boundary);
+    }
     let mut conn = match C::connect_with_config(info, config).await {
         Ok(conn) => conn,
         Err(err) => {
@@ -1570,6 +1762,6 @@ where
 {
     connections
         .iter()
+        .filter_map(|(addr, state)| state.connected().map(|conn| (addr.clone(), conn)))
         .choose(&mut rng())
-        .map(|(addr, conn)| (addr.clone(), conn.clone()))
 }

--- a/redis/src/cluster_handling/async_connection/routing.rs
+++ b/redis/src/cluster_handling/async_connection/routing.rs
@@ -1,8 +1,8 @@
 use crate::{
-    Cmd, RedisResult,
+    RedisResult,
     cluster_handling::NodeAddress,
     cluster_routing::{
-        MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
+        MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Routable, Route, RoutingInfo,
         SingleNodeRoutingInfo, SlotAddr,
     },
     errors::ServerErrorKind,
@@ -97,7 +97,7 @@ impl<C> From<SingleNodeRoutingInfo> for InternalSingleNodeRouting<C> {
 }
 
 pub(super) fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> {
-    fn route_for_command(cmd: &Cmd) -> Option<Route> {
+    fn route_for_command(cmd: &impl Routable) -> Option<Route> {
         match RoutingInfo::for_routable(cmd) {
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
@@ -114,26 +114,28 @@ pub(super) fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Opti
 
     // Find first specific slot and send to it. There's no need to check If later commands
     // should be routed to a different slot, since the server will return an error indicating this.
-    pipeline.cmd_iter().map(route_for_command).try_fold(
-        None,
-        |chosen_route, next_cmd_route| match (chosen_route, next_cmd_route) {
-            (None, _) => Ok(next_cmd_route),
-            (_, None) => Ok(chosen_route),
-            (Some(chosen_route), Some(next_cmd_route)) => {
-                if chosen_route.slot() != next_cmd_route.slot() {
-                    Err((
-                        ServerErrorKind::CrossSlot.into(),
-                        "Received crossed slots in pipeline",
-                    )
-                        .into())
-                } else if chosen_route.slot_addr() != SlotAddr::Master {
-                    Ok(Some(next_cmd_route))
-                } else {
-                    Ok(Some(chosen_route))
+    pipeline
+        .cmd_iter()
+        .map(|cmd| route_for_command(&cmd))
+        .try_fold(None, |chosen_route, next_cmd_route| {
+            match (chosen_route, next_cmd_route) {
+                (None, _) => Ok(next_cmd_route),
+                (_, None) => Ok(chosen_route),
+                (Some(chosen_route), Some(next_cmd_route)) => {
+                    if chosen_route.slot() != next_cmd_route.slot() {
+                        Err((
+                            ServerErrorKind::CrossSlot.into(),
+                            "Received crossed slots in pipeline",
+                        )
+                            .into())
+                    } else if chosen_route.slot_addr() != SlotAddr::Master {
+                        Ok(Some(next_cmd_route))
+                    } else {
+                        Ok(Some(chosen_route))
+                    }
                 }
             }
-        },
-    )
+        })
 }
 
 #[cfg(test)]

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -69,6 +69,8 @@ struct BuilderParams {
     overall_response_timeout: OverallResponseTimeout,
     #[cfg(feature = "cluster-async")]
     connection_concurrency_limit: Option<usize>,
+    #[cfg(feature = "cluster-async")]
+    write_backpressure_boundary: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -155,6 +157,8 @@ pub(crate) struct ClusterParams {
     pub(crate) overall_response_timeout: Option<Duration>,
     #[cfg(feature = "cluster-async")]
     pub(crate) connection_concurrency_limit: Option<usize>,
+    #[cfg(feature = "cluster-async")]
+    pub(crate) write_backpressure_boundary: Option<usize>,
 }
 
 impl ClusterParams {
@@ -219,6 +223,8 @@ impl ClusterParams {
             },
             #[cfg(feature = "cluster-async")]
             connection_concurrency_limit: value.connection_concurrency_limit,
+            #[cfg(feature = "cluster-async")]
+            write_backpressure_boundary: value.write_backpressure_boundary,
         })
     }
 
@@ -671,6 +677,18 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Sets the flush threshold (backpressure boundary) for each node connection's outbound write buffer.
+    ///
+    /// See [`crate::AsyncConnectionConfig::set_write_backpressure_boundary`] for full semantics.
+    /// This value is applied identically to every node connection in the cluster.
+    ///
+    /// When left unset, connections keep `tokio_util`'s default boundary.
+    #[cfg(feature = "cluster-async")]
+    pub fn write_backpressure_boundary(mut self, boundary: usize) -> ClusterClientBuilder {
+        self.builder_params.write_backpressure_boundary = Some(boundary);
+        self
+    }
+
     /// Sets a credentials provider for dynamic authentication (e.g., token-based authentication)
     /// on all cluster node connections.
     ///
@@ -1071,6 +1089,26 @@ mod tests {
         assert_eq!(
             client.cluster_params.connection_concurrency_limit,
             Some(128)
+        );
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn write_backpressure_boundary_default() {
+        let client = ClusterClient::new(get_connection_data()).unwrap();
+        assert_eq!(client.cluster_params.write_backpressure_boundary, None);
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn write_backpressure_boundary_custom() {
+        let client = ClusterClientBuilder::new(get_connection_data())
+            .write_backpressure_boundary(16 * 1024 * 1024)
+            .build()
+            .unwrap();
+        assert_eq!(
+            client.cluster_params.write_backpressure_boundary,
+            Some(16 * 1024 * 1024)
         );
     }
 

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -2,7 +2,7 @@ use rand::RngExt;
 
 use super::NodeAddress;
 use crate::cluster_handling::slot_map::SLOT_SIZE;
-use crate::cmd::{Arg, Cmd};
+use crate::cmd::{Arg, Cmd, CmdRef};
 use crate::commands::is_readonly_cmd;
 use crate::types::Value;
 use crate::{ErrorKind, RedisError, RedisResult};
@@ -891,6 +891,19 @@ pub(crate) trait Routable {
 impl Routable for Cmd {
     fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
         self.arg_idx(idx)
+    }
+
+    fn position(&self, candidate: &[u8]) -> Option<usize> {
+        self.args_iter().position(|a| match a {
+            Arg::Simple(d) => d.eq_ignore_ascii_case(candidate),
+            _ => false,
+        })
+    }
+}
+
+impl Routable for CmdRef<'_> {
+    fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
+        CmdRef::arg_idx(self, idx)
     }
 
     fn position(&self, candidate: &[u8]) -> Option<usize> {

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -46,6 +46,23 @@ impl SlotMap {
             .map(|addrs| addrs.slot_addr(slot, &route.slot_addr(), strategy))
     }
 
+    // TODO - Include the routing strategy in the fallback logic too.
+    #[cfg(feature = "cluster-async")]
+    pub(crate) fn shard_fallback_addrs(&self, route: &Route) -> Vec<NodeAddress> {
+        let Some(addrs) = self.slots.get(route.slot()) else {
+            return Vec::new();
+        };
+        match route.slot_addr() {
+            SlotAddr::Master => vec![],
+            SlotAddr::ReplicaOptional => {
+                let mut candidates = addrs.replicas.clone();
+                candidates.push(addrs.primary.clone());
+                candidates
+            }
+            SlotAddr::ReplicaRequired => addrs.replicas.clone(),
+        }
+    }
+
     #[cfg(feature = "cluster-async")]
     pub fn clear(&mut self) {
         self.slots.clear();
@@ -339,6 +356,64 @@ mod tests {
                 .unwrap(),
             "replica1:6379"
         );
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn test_shard_fallback_addrs_master_is_empty() {
+        let slot_map = get_slot_map();
+        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
+            Slot::new(1500).unwrap(),
+            SlotAddr::Master,
+        ));
+        assert!(fallback.is_empty());
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn test_shard_fallback_addrs_replica_optional() {
+        let slot_map = get_slot_map();
+        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
+            Slot::new(1500).unwrap(),
+            SlotAddr::ReplicaOptional,
+        ));
+        assert_eq!(
+            fallback,
+            vec![
+                addr("replica2:6379"),
+                addr("replica3:6379"),
+                addr("node2:6379")
+            ]
+        );
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn test_shard_fallback_addrs_replica_requiredy() {
+        let slot_map = get_slot_map();
+        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
+            Slot::new(2500).unwrap(),
+            SlotAddr::ReplicaRequired,
+        ));
+        assert_eq!(
+            fallback,
+            vec![
+                addr("replica4:6379"),
+                addr("replica5:6379"),
+                addr("replica6:6379")
+            ]
+        );
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn test_shard_fallback_addrs_missing_slot_is_empty() {
+        let slot_map = get_slot_map();
+        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
+            Slot::new(1001).unwrap(),
+            SlotAddr::ReplicaOptional,
+        ));
+        assert!(fallback.is_empty());
     }
 
     fn get_slot_map() -> SlotMap {

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -398,7 +398,8 @@ where
     }
 
     pub(crate) fn execute_pipeline(&mut self, pipe: &ClusterPipeline) -> RedisResult<Vec<Value>> {
-        self.send_recv_and_retry_cmds(pipe.commands())
+        let cmds: Vec<Cmd> = pipe.cmd_iter().map(|cmd| cmd.to_cmd()).collect();
+        self.send_recv_and_retry_cmds(&cmds)
     }
 
     /// Returns the connection status.

--- a/redis/src/cluster_handling/sync_connection/pipeline.rs
+++ b/redis/src/cluster_handling/sync_connection/pipeline.rs
@@ -1,8 +1,9 @@
 use super::ClusterConnection;
 use crate::RedisError;
-use crate::cmd::{Cmd, cmd};
+use crate::cmd::{Arg, Cmd, CmdRef};
 use crate::errors::ErrorKind;
-use crate::types::{FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value, from_redis_value};
+use crate::pipeline::CommandRecord;
+use crate::types::{FromRedisValue, RedisResult, ToRedisArgs, Value, from_redis_value};
 
 pub(crate) const UNROUTABLE_ERROR: (ErrorKind, &str) = (
     ErrorKind::Client,
@@ -44,8 +45,9 @@ fn is_illegal_cmd(cmd: &str) -> bool {
 /// Represents a Redis Cluster command pipeline.
 #[derive(Clone)]
 pub struct ClusterPipeline {
-    commands: Vec<Cmd>,
-    ignored_commands: HashSet<usize>,
+    data: Vec<u8>,
+    args: Vec<Arg<usize>>,
+    commands: Vec<CommandRecord>,
     ignore_errors: bool,
 }
 
@@ -73,21 +75,18 @@ pub struct ClusterPipeline {
 /// ```
 impl ClusterPipeline {
     /// Create an empty pipeline.
+    ///
+    /// To pre-allocate the internal buffers when you have a size estimate, chain the
+    /// [`reserve_for_commands`](Self::reserve_for_commands),
+    /// [`reserve_for_args`](Self::reserve_for_args), and
+    /// [`reserve_for_data`](Self::reserve_for_data) methods.
     pub fn new() -> ClusterPipeline {
-        Self::with_capacity(0)
-    }
-
-    /// Creates an empty pipeline with pre-allocated capacity.
-    pub fn with_capacity(capacity: usize) -> ClusterPipeline {
         ClusterPipeline {
-            commands: Vec::with_capacity(capacity),
-            ignored_commands: HashSet::new(),
+            data: Vec::new(),
+            args: Vec::new(),
+            commands: Vec::new(),
             ignore_errors: false,
         }
-    }
-
-    pub(crate) fn commands(&self) -> &Vec<Cmd> {
-        &self.commands
     }
 
     /// Executes the pipeline and fetches the return values:
@@ -105,7 +104,7 @@ impl ClusterPipeline {
     /// ```
     #[inline]
     pub fn query<T: FromRedisValue>(&self, con: &mut ClusterConnection) -> RedisResult<T> {
-        for cmd in &self.commands {
+        for cmd in self.cmd_iter() {
             let cmd_name = std::str::from_utf8(cmd.arg_idx(0).unwrap_or(b""))
                 .unwrap_or("")
                 .trim()

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -24,6 +24,158 @@ pub enum Arg<D> {
     Cursor,
 }
 
+/// A lightweight, borrowed view of a single command.
+///
+/// `CmdRef` is the item type yielded by [`Pipeline::cmd_iter`](crate::Pipeline::cmd_iter).
+/// It borrows directly into the pipeline's shared buffers, so iterating the commands of a
+/// pipeline performs no per-command allocation. It can also be created from a standalone
+/// [`Cmd`], which lets internal machinery treat both uniformly.
+///
+/// The type is intentionally opaque: it exposes a curated set of read-only accessors so that
+/// the underlying storage can evolve without breaking callers.
+#[derive(Clone, Copy, Debug)]
+pub struct CmdRef<'a> {
+    // The contiguous argument bytes belonging to this command.
+    data: &'a [u8],
+    // This command's args. `Arg::Simple` offsets are absolute into the buffer that `data` is a
+    // slice of; `data_start` records where `data` begins within it.
+    args: &'a [Arg<usize>],
+    data_start: usize,
+    cursor: Option<u64>,
+    no_response: bool,
+    ignored: bool,
+    #[cfg(feature = "cache-aio")]
+    cache: &'a Option<CommandCacheConfig>,
+}
+
+impl<'a> CmdRef<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        data: &'a [u8],
+        args: &'a [Arg<usize>],
+        data_start: usize,
+        cursor: Option<u64>,
+        no_response: bool,
+        ignored: bool,
+        #[cfg(feature = "cache-aio")] cache: &'a Option<CommandCacheConfig>,
+    ) -> Self {
+        CmdRef {
+            data,
+            args,
+            data_start,
+            cursor,
+            no_response,
+            ignored,
+            #[cfg(feature = "cache-aio")]
+            cache,
+        }
+    }
+
+    /// Creates a view borrowing from a standalone [`Cmd`].
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn from_cmd(cmd: &'a Cmd) -> Self {
+        CmdRef {
+            data: &cmd.data,
+            args: &cmd.args,
+            data_start: 0,
+            cursor: cmd.cursor,
+            no_response: cmd.no_response,
+            ignored: false,
+            #[cfg(feature = "cache-aio")]
+            cache: &cmd.cache,
+        }
+    }
+
+    /// Returns an iterator over the arguments in this command (including the command name itself).
+    pub fn args_iter(&self) -> impl Clone + ExactSizeIterator<Item = Arg<&'a [u8]>> + use<'a> {
+        let data = self.data;
+        let base = self.data_start;
+        let args = self.args;
+        let mut prev = 0;
+        args.iter().map(move |arg| match *arg {
+            Arg::Simple(end) => {
+                let arg = Arg::Simple(&data[prev..end - base]);
+                prev = end - base;
+                arg
+            }
+            Arg::Cursor => Arg::Cursor,
+        })
+    }
+
+    /// Returns a reference to the data for the argument at `idx`.
+    pub fn arg_idx(&self, idx: usize) -> Option<&'a [u8]> {
+        match self.args_iter().nth(idx)? {
+            Arg::Simple(bytes) => Some(bytes),
+            Arg::Cursor => None,
+        }
+    }
+
+    /// Returns this command's contiguous argument bytes.
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    /// Returns the command's cursor value, if it is in scan mode.
+    pub fn cursor(&self) -> Option<u64> {
+        self.cursor
+    }
+
+    /// Check whether the command's result will be waited for.
+    pub fn is_no_response(&self) -> bool {
+        self.no_response
+    }
+
+    /// Returns `true` if this command's result is ignored within the pipeline.
+    pub fn is_ignored(&self) -> bool {
+        self.ignored
+    }
+
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn get_cache_config(&self) -> &'a Option<CommandCacheConfig> {
+        self.cache
+    }
+
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn encoded_len(&self) -> usize {
+        args_len(self.args_iter(), self.cursor.unwrap_or(0))
+    }
+
+    /// Returns the packed command as a byte vector.
+    pub fn get_packed_command(&self) -> Vec<u8> {
+        let mut cmd = Vec::new();
+        if self.args.is_empty() {
+            return cmd;
+        }
+        self.write_packed_command(&mut cmd);
+        cmd
+    }
+
+    /// Writes the packed command to `dst`, appending to it.
+    pub fn write_packed_command(&self, dst: &mut Vec<u8>) {
+        write_command_to_vec(dst, self.args_iter(), self.cursor.unwrap_or(0))
+    }
+
+    /// Reconstructs an owned [`Cmd`] from this view.
+    pub fn to_cmd(self) -> Cmd {
+        let mut cmd = Cmd::with_capacity(self.args.len(), self.data.len());
+        cmd.data.extend_from_slice(self.data);
+        let base = self.data_start;
+        for arg in self.args {
+            match *arg {
+                Arg::Simple(end) => cmd.args.push(Arg::Simple(end - base)),
+                Arg::Cursor => cmd.args.push(Arg::Cursor),
+            }
+        }
+        cmd.cursor = self.cursor;
+        cmd.no_response = self.no_response;
+        #[cfg(feature = "cache-aio")]
+        {
+            cmd.cache = self.cache.clone();
+        }
+        cmd
+    }
+}
+
 /// CommandCacheConfig is used to define caching behaviour of individual commands.
 /// # Example
 /// ```rust
@@ -295,7 +447,7 @@ fn bulklen(len: usize) -> usize {
     1 + countdigits(len) + 2 + len + 2
 }
 
-fn args_len<'a, I>(args: I, cursor: u64) -> usize
+pub(crate) fn args_len<'a, I>(args: I, cursor: u64) -> usize
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + ExactSizeIterator,
 {
@@ -309,6 +461,7 @@ where
     totlen
 }
 
+#[cfg(test)]
 pub(crate) fn cmd_len(cmd: &Cmd) -> usize {
     args_len(cmd.args_iter(), cmd.cursor.unwrap_or(0))
 }
@@ -333,7 +486,11 @@ where
     write_command(cmd, args, cursor).unwrap()
 }
 
-fn write_command<'a, I>(cmd: &mut (impl ?Sized + Write), args: I, cursor: u64) -> io::Result<()>
+pub(crate) fn write_command<'a, I>(
+    cmd: &mut (impl ?Sized + Write),
+    args: I,
+    cursor: u64,
+) -> io::Result<()>
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + Clone + ExactSizeIterator,
 {
@@ -624,14 +781,14 @@ impl Cmd {
         write_command_to_vec(dst, self.args_iter(), self.cursor.unwrap_or(0))
     }
 
-    pub(crate) fn write_packed_command_preallocated(&self, cmd: &mut Vec<u8>) {
-        write_command(cmd, self.args_iter(), self.cursor.unwrap_or(0)).unwrap()
-    }
-
     /// Returns true if the command is in scan mode.
     #[inline]
     pub fn in_scan_mode(&self) -> bool {
         self.cursor.is_some()
+    }
+
+    pub(crate) fn cursor_value(&self) -> Option<u64> {
+        self.cursor
     }
 
     /// Sends the command as query to the connection and converts the
@@ -773,7 +930,7 @@ impl Cmd {
     }
 
     // Get a reference to the argument at `idx`
-    #[cfg(any(feature = "cluster", feature = "cache-aio"))]
+    #[cfg(feature = "cluster")]
     pub(crate) fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
         if idx >= self.args.len() {
             return None;

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -8,7 +8,7 @@ use futures_util::{
 use std::pin::Pin;
 #[cfg(feature = "cache-aio")]
 use std::time::Duration;
-use std::{fmt, io, io::Write};
+use std::{fmt, io::Write};
 
 use crate::pipeline::Pipeline;
 use crate::types::{FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, from_redis_value};
@@ -483,23 +483,18 @@ where
 
     cmd.reserve(totlen);
 
-    write_command(cmd, args, cursor).unwrap()
+    write_command(cmd, args, cursor)
 }
 
-pub(crate) fn write_command<'a, I>(
-    cmd: &mut (impl ?Sized + Write),
-    args: I,
-    cursor: u64,
-) -> io::Result<()>
+pub(crate) fn write_command<'a, I>(cmd: &mut Vec<u8>, args: I, cursor: u64)
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + Clone + ExactSizeIterator,
 {
     let mut buf = ::itoa::Buffer::new();
 
-    cmd.write_all(b"*")?;
-    let s = buf.format(args.len());
-    cmd.write_all(s.as_bytes())?;
-    cmd.write_all(b"\r\n")?;
+    cmd.extend_from_slice(b"*");
+    cmd.extend_from_slice(buf.format(args.len()).as_bytes());
+    cmd.extend_from_slice(b"\r\n");
 
     let mut cursor_bytes = itoa::Buffer::new();
     for item in args {
@@ -508,15 +503,13 @@ where
             Arg::Simple(val) => val,
         };
 
-        cmd.write_all(b"$")?;
-        let s = buf.format(bytes.len());
-        cmd.write_all(s.as_bytes())?;
-        cmd.write_all(b"\r\n")?;
+        cmd.extend_from_slice(b"$");
+        cmd.extend_from_slice(buf.format(bytes.len()).as_bytes());
+        cmd.extend_from_slice(b"\r\n");
 
-        cmd.write_all(bytes)?;
-        cmd.write_all(b"\r\n")?;
+        cmd.extend_from_slice(bytes);
+        cmd.extend_from_slice(b"\r\n");
     }
-    Ok(())
 }
 
 impl RedisWrite for Cmd {

--- a/redis/src/commands/geo.rs
+++ b/redis/src/commands/geo.rs
@@ -144,6 +144,7 @@ pub enum RadiusOrder {
 pub struct RadiusOptions {
     with_coord: bool,
     with_dist: bool,
+    with_hash: bool,
     count: Option<usize>,
     order: RadiusOrder,
     store: Option<Vec<Vec<u8>>>,
@@ -168,6 +169,12 @@ impl RadiusOptions {
     /// Return the `longitude, latitude` coordinates of the matching items.
     pub fn with_coord(mut self) -> Self {
         self.with_coord = true;
+        self
+    }
+
+    /// Return the server's raw geohash score of each matching item.
+    pub fn with_hash(mut self) -> Self {
+        self.with_hash = true;
         self
     }
 
@@ -206,6 +213,10 @@ impl ToRedisArgs for RadiusOptions {
             out.write_arg(b"WITHDIST");
         }
 
+        if self.with_hash {
+            out.write_arg(b"WITHHASH");
+        }
+
         if let Some(n) = self.count {
             out.write_arg(b"COUNT");
             out.write_arg_fmt(n);
@@ -240,6 +251,9 @@ impl ToRedisArgs for RadiusOptions {
         if self.with_dist {
             n += 1;
         }
+        if self.with_hash {
+            n += 1;
+        }
         if self.count.is_some() {
             n += 2;
         }
@@ -265,6 +279,8 @@ pub struct RadiusSearchResult {
     pub coord: Option<Coord<f64>>,
     /// The distance if available.
     pub dist: Option<f64>,
+    /// The geohash if available.
+    pub hash: Option<i64>,
 }
 
 impl FromRedisValue for RadiusSearchResult {
@@ -276,6 +292,7 @@ impl FromRedisValue for RadiusSearchResult {
                     name: s,
                     coord: None,
                     dist: None,
+                    hash: None,
                 })
             }
             Value::Array(items) => RadiusSearchResult::parse_multi_values(items),
@@ -294,25 +311,51 @@ impl RadiusSearchResult {
             _ => return Err(arcstr::literal!("Missing member name").into()),
         };
 
-        let (dist, coord) = match (iter.next(), iter.next()) {
-            (None, None) => (None, None),
-            (Some(Value::Array(coords)), None) => {
-                (None, Some(Coord::from_redis_value(Value::Array(coords))?))
-            }
-            (Some(dist), coord) => {
-                let dist = FromRedisValue::from_redis_value(dist)?;
+        // The remaining fields are optional. As their order is fixed and their types are different,
+        // we can parse piece by piece to avoid combinatorial explosion of having to cover all
+        // cases.
 
-                let coord = match coord.map(FromRedisValue::from_redis_value) {
-                    Some(Ok(c)) => Some(c),
-                    _ => None,
-                };
+        // The fields we need to fill
+        let mut coord = None;
+        let mut hash = None;
+        let mut dist = None;
 
-                (dist, coord)
-            }
-            _ => invalid_type_error!("Response type not RadiusSearchResult compatible."),
+        // The next value to parse to one of the fields.
+        let mut opt_value = iter.next();
+
+        // If present, the distance is first
+        if let Some(dist_value) = &opt_value
+            && matches!(dist_value, Value::BulkString(_))
+        {
+            dist = Some(f64::from_redis_value_ref(dist_value)?);
+            opt_value = iter.next();
+        }
+
+        // If present, the hash is second
+        if let Some(Value::Int(hash_ref)) = &opt_value {
+            hash = Some(*hash_ref);
+            opt_value = iter.next();
+        }
+
+        // If present, the coordinates are third
+        if let Some(coords_value) = &opt_value
+            && matches!(coords_value, Value::Array(_))
+        {
+            coord = Some(Coord::from_redis_value_ref(coords_value)?);
+            opt_value = iter.next();
+        }
+
+        // We should have parsed all that's there. So we flag an error, if there is more.
+        if opt_value.is_some() {
+            invalid_type_error!("Response type not RadiusSearchResult compatible.")
         };
 
-        Ok(RadiusSearchResult { name, coord, dist })
+        Ok(RadiusSearchResult {
+            name,
+            coord,
+            dist,
+            hash,
+        })
     }
 }
 
@@ -347,7 +390,12 @@ mod tests {
         // Some combinations with WITH* options
         let opts = RadiusOptions::default;
 
-        assert_args!(opts().with_coord().with_dist(), "WITHCOORD", "WITHDIST");
+        assert_args!(
+            opts().with_coord().with_dist().with_hash(),
+            "WITHCOORD",
+            "WITHDIST",
+            "WITHHASH"
+        );
 
         assert_args!(opts().limit(50), "COUNT", "50");
 

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -8,16 +8,12 @@ macro_rules! implement_command_async {
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
             $($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
-        $(#[$attr])*
-        #[inline]
-        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-        fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-            & $lifetime mut self
-            $(, $argname: $argty)*
-        ) -> crate::types::RedisFuture<$lifetime, RV>
-        {
-            Box::pin(async move { $body.query_async(self).await })
-        }
+        implement_command_async!(
+            $lifetime
+            $(#[$attr])+
+            fn $name<$($tyargs : $ty,)* RV: FromRedisValue>(
+                $($argname: $argty),*) $body RV
+        );
     };
 
     // If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
@@ -49,16 +45,12 @@ macro_rules! implement_command_sync {
         fn $name:ident<$($tyargs:ident : $ty:ident),*>(
             $($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
-        $(#[$attr])*
-        #[inline]
-        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-        fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-            & $lifetime mut self
-            $(, $argname: $argty)*
-        ) -> RedisResult<RV>
-        {
-            Cmd::$name($($argname),*).query(self)
-        }
+        implement_command_sync!(
+            $lifetime
+            $(#[$attr])+
+            fn $name<$($tyargs : $ty,)* RV: FromRedisValue>(
+                $($argname: $argty),*) $body RV
+        );
     };
 
     // If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -3805,22 +3805,23 @@ impl ToRedisArgs for Expiry {
     where
         W: ?Sized + RedisWrite,
     {
+        let mut buf = ::itoa::Buffer::new();
         match self {
             Expiry::EX(sec) => {
                 out.write_arg(b"EX");
-                out.write_arg(sec.to_string().as_bytes());
+                out.write_arg(buf.format(*sec).as_bytes());
             }
             Expiry::PX(ms) => {
                 out.write_arg(b"PX");
-                out.write_arg(ms.to_string().as_bytes());
+                out.write_arg(buf.format(*ms).as_bytes());
             }
             Expiry::EXAT(timestamp_sec) => {
                 out.write_arg(b"EXAT");
-                out.write_arg(timestamp_sec.to_string().as_bytes());
+                out.write_arg(buf.format(*timestamp_sec).as_bytes());
             }
             Expiry::PXAT(timestamp_ms) => {
                 out.write_arg(b"PXAT");
-                out.write_arg(timestamp_ms.to_string().as_bytes());
+                out.write_arg(buf.format(*timestamp_ms).as_bytes());
             }
             Expiry::PERSIST => {
                 out.write_arg(b"PERSIST");

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1108,49 +1108,16 @@ implement_commands! {
     /// Intersect multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).take()
+    fn zinterstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
-    /// a new key using MIN as aggregation function.
+    /// a new key, applying per-key `WEIGHTS` and an optional `AGGREGATE` modifier.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_min<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").take()
-    }
-
-    /// Intersect multiple sorted sets and store the resulting sorted set in
-    /// a new key using MAX as aggregation function.
-    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_max<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").take()
-    }
-
-    /// [`Commands::zinterstore`], but with the ability to specify a
-    /// multiplication factor for each sorted set by pairing one with each key
-    /// in a tuple.
-    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).take()
-    }
-
-    /// [`Commands::zinterstore_min`], but with the ability to specify a
-    /// multiplication factor for each sorted set by pairing one with each key
-    /// in a tuple.
-    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_min_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights).take()
-    }
-
-    /// [`Commands::zinterstore_max`], but with the ability to specify a
-    /// multiplication factor for each sorted set by pairing one with each key
-    /// in a tuple.
-    /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
-    fn zinterstore_max_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
-        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights).take()
+    fn zinterstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
@@ -1386,49 +1353,16 @@ implement_commands! {
     /// Unions multiple sorted sets and store the resulting sorted set in
     /// a new key using SUM as aggregation function.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).take()
+    fn zunionstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
     }
 
     /// Unions multiple sorted sets and store the resulting sorted set in
-    /// a new key using MIN as aggregation function.
+    /// a new key, applying per-key `WEIGHTS` and an optional `AGGREGATE` modifier.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_min<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").take()
-    }
-
-    /// Unions multiple sorted sets and store the resulting sorted set in
-    /// a new key using MAX as aggregation function.
-    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_max<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K) -> (usize) {
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").take()
-    }
-
-    /// [`Commands::zunionstore`], but with the ability to specify a
-    /// multiplication factor for each sorted set by pairing one with each key
-    /// in a tuple.
-    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).take()
-    }
-
-    /// [`Commands::zunionstore_min`], but with the ability to specify a
-    /// multiplication factor for each sorted set by pairing one with each key
-    /// in a tuple.
-    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_min_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MIN").arg("WEIGHTS").arg(weights).take()
-    }
-
-    /// [`Commands::zunionstore_max`], but with the ability to specify a
-    /// multiplication factor for each sorted set by pairing one with each key
-    /// in a tuple.
-    /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
-    fn zunionstore_max_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)]) -> (usize) {
-        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(key, weight):&(K, W)| -> ((&K, &W)) {(key, weight)}).unzip();
-        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("AGGREGATE").arg("MAX").arg("WEIGHTS").arg(weights).take()
+    fn zunionstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
     }
 
     // vector set commands
@@ -3926,6 +3860,78 @@ impl ToRedisArgs for SortedSetAddOptions {
         }
         if self.increment {
             out.write_arg(b"INCR")
+        }
+    }
+}
+
+/// Aggregation function used by the `ZINTERSTORE` and `ZUNIONSTORE` commands to
+/// combine the scores of members that appear in more than one input sorted set.
+#[derive(Clone, Copy)]
+#[non_exhaustive]
+pub enum Aggregate {
+    /// Sum the scores of matching members (the Redis default).
+    Sum,
+    /// Use the minimum score of matching members.
+    Min,
+    /// Use the maximum score of matching members.
+    Max,
+}
+
+impl ToRedisArgs for Aggregate {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        let s: &[u8] = match self {
+            Aggregate::Sum => b"SUM",
+            Aggregate::Min => b"MIN",
+            Aggregate::Max => b"MAX",
+        };
+        out.write_arg(s);
+    }
+}
+
+/// Options for the [ZINTERSTORE](https://redis.io/commands/zinterstore) and
+/// [ZUNIONSTORE](https://redis.io/commands/zunionstore) commands.
+///
+/// Controls the optional `AGGREGATE` modifier. For weighted variants use
+/// [`Commands::zinterstore_with_weights`] / [`Commands::zunionstore_with_weights`].
+///
+/// # Example
+/// ```rust,no_run
+/// use redis::{Commands, RedisResult, SortedSetOperationOptions, Aggregate};
+/// fn intersect(con: &mut redis::Connection) -> RedisResult<usize> {
+///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default())
+/// }
+/// fn intersect_min(con: &mut redis::Connection) -> RedisResult<usize> {
+///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_weighted(con: &mut redis::Connection) -> RedisResult<usize> {
+///     con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// ```
+#[derive(Clone, Default)]
+pub struct SortedSetOperationOptions {
+    aggregate: Option<Aggregate>,
+}
+
+impl SortedSetOperationOptions {
+    /// Sets the `AGGREGATE` modifier used to combine the scores of members that
+    /// appear in more than one input sorted set.
+    pub fn aggregate(mut self, aggregate: Aggregate) -> Self {
+        self.aggregate = Some(aggregate);
+        self
+    }
+}
+
+impl ToRedisArgs for SortedSetOperationOptions {
+    fn write_redis_args<Out>(&self, out: &mut Out)
+    where
+        Out: ?Sized + RedisWrite,
+    {
+        if let Some(ref aggregate) = self.aggregate {
+            out.write_arg(b"AGGREGATE");
+            aggregate.write_redis_args(out);
         }
     }
 }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1106,7 +1106,8 @@ implement_commands! {
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
-    /// a new key using SUM as aggregation function.
+    /// a new key, optionally applying an `AGGREGATE` modifier.
+    /// If no `AGGREGATE` modifier is provided, `SUM` is used.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
@@ -1118,6 +1119,34 @@ implement_commands! {
     fn zinterstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// Intersect multiple sorted sets and return the resulting members,
+    /// applying an optional `AGGREGATE` modifier (SUM by default).
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<String>) {
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg(options).take()
+    }
+
+    /// [`Commands::zinter`], but with the ability to specify a weight for each
+    /// sorted set by pairing each key with its corresponding weight.
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter_with_weights<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<String>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// [`Commands::zinter`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter_withscores<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg(options).arg("WITHSCORES").take()
+    }
+
+    /// [`Commands::zinter_with_weights`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter_with_weights_withscores<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).arg("WITHSCORES").take()
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
@@ -1350,19 +1379,48 @@ implement_commands! {
         cmd("ZMSCORE").arg(key).arg(members).take()
     }
 
-    /// Unions multiple sorted sets and store the resulting sorted set in
-    /// a new key using SUM as aggregation function.
+    /// Union multiple sorted sets and store the resulting sorted set in
+    /// a new key, optionally applying an `AGGREGATE` modifier.
+    /// If no `AGGREGATE` modifier is provided, `SUM` is used.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
     }
 
-    /// Unions multiple sorted sets and store the resulting sorted set in
+    /// Union multiple sorted sets and store the resulting sorted set in
     /// a new key, applying per-key `WEIGHTS` and an optional `AGGREGATE` modifier.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// Union multiple sorted sets and return the resulting members,
+    /// applying an optional `AGGREGATE` modifier (SUM by default).
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<String>) {
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg(options).take()
+    }
+
+    /// [`Commands::zunion`], but with the ability to specify a weight for each
+    /// sorted set by pairing each key with its corresponding weight.
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion_with_weights<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<String>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// [`Commands::zunion`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion_withscores<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg(options).arg("WITHSCORES").take()
+    }
+
+    /// [`Commands::zunion_with_weights`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion_with_weights_withscores<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).arg("WITHSCORES").take()
     }
 
     // vector set commands
@@ -3864,8 +3922,9 @@ impl ToRedisArgs for SortedSetAddOptions {
     }
 }
 
-/// Aggregation function used by the `ZINTERSTORE` and `ZUNIONSTORE` commands to
-/// combine the scores of members that appear in more than one input sorted set.
+/// Aggregation function used by the `ZINTERSTORE`, `ZUNIONSTORE`, `ZINTER` and
+/// `ZUNION` commands to combine the scores of members that appear in more than
+/// one input sorted set.
 #[derive(Clone, Copy)]
 #[non_exhaustive]
 pub enum Aggregate {
@@ -3875,6 +3934,12 @@ pub enum Aggregate {
     Min,
     /// Use the maximum score of matching members.
     Max,
+    /// Ignore the input scores and instead sum the per-set weights of the sets
+    /// that contain each member (with default weights of `1`, this is the
+    /// number of input sets that contain the member).
+    ///
+    /// Requires Redis 8.8 or later.
+    Count,
 }
 
 impl ToRedisArgs for Aggregate {
@@ -3886,28 +3951,56 @@ impl ToRedisArgs for Aggregate {
             Aggregate::Sum => b"SUM",
             Aggregate::Min => b"MIN",
             Aggregate::Max => b"MAX",
+            Aggregate::Count => b"COUNT",
         };
         out.write_arg(s);
     }
 }
 
 /// Options for the [ZINTERSTORE](https://redis.io/commands/zinterstore) and
-/// [ZUNIONSTORE](https://redis.io/commands/zunionstore) commands.
+/// [ZUNIONSTORE](https://redis.io/commands/zunionstore) commands and their respective non-store variants
+/// [`ZINTER`](https://redis.io/commands/zinter) and [`ZUNION`](https://redis.io/commands/zunion).
 ///
-/// Controls the optional `AGGREGATE` modifier. For weighted variants use
-/// [`Commands::zinterstore_with_weights`] / [`Commands::zunionstore_with_weights`].
+/// Controls the optional `AGGREGATE` modifier. For weighted operations, use
+/// [`Commands::zinterstore_with_weights`] / [`Commands::zunionstore_with_weights`] or
+/// [`Commands::zinter_with_weights`] / [`Commands::zunion_with_weights`].
+/// The non-store commands also provide
+/// [`Commands::zinter_withscores`] / [`Commands::zunion_withscores`] to return member scores and
+/// [`Commands::zinter_with_weights_withscores`] / [`Commands::zunion_with_weights_withscores`] to return scores for weighted operations.
 ///
 /// # Example
 /// ```rust,no_run
 /// use redis::{Commands, RedisResult, SortedSetOperationOptions, Aggregate};
-/// fn intersect(con: &mut redis::Connection) -> RedisResult<usize> {
+/// fn intersect_and_store(con: &mut redis::Connection) -> RedisResult<usize> {
 ///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default())
 /// }
-/// fn intersect_min(con: &mut redis::Connection) -> RedisResult<usize> {
+/// fn intersect(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter(&["zset1", "zset2"], SortedSetOperationOptions::default())
+/// }
+/// fn intersect_min_and_store(con: &mut redis::Connection) -> RedisResult<usize> {
 ///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
 /// }
-/// fn intersect_weighted(con: &mut redis::Connection) -> RedisResult<usize> {
+/// fn intersect_min(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter(&["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_weighted_and_store(con: &mut redis::Connection) -> RedisResult<usize> {
 ///     con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_weighted(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_min_with_scores(con: &mut redis::Connection) -> RedisResult<Vec<(String, f64)>> {
+///     con.zinter_withscores(&["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_weighted_with_scores(con: &mut redis::Connection) -> RedisResult<Vec<(String, f64)>> {
+///     con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// // Count the number of input sets each member appears in (Redis 8.8+):
+/// fn store_membership_counts(con: &mut redis::Connection) -> RedisResult<usize> {
+///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Count))
+/// }
+/// fn membership_counts(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter(&["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Count))
 /// }
 /// ```
 #[derive(Clone, Default)]
@@ -3916,8 +4009,7 @@ pub struct SortedSetOperationOptions {
 }
 
 impl SortedSetOperationOptions {
-    /// Sets the `AGGREGATE` modifier used to combine the scores of members that
-    /// appear in more than one input sorted set.
+    /// Sets the `AGGREGATE` modifier used when combining scores from the input sorted sets.
     pub fn aggregate(mut self, aggregate: Aggregate) -> Self {
         self.aggregate = Some(aggregate);
         self

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -2484,8 +2484,7 @@ mod tests {
             .0;
 
             let actual_packed_cmds = pipeline
-                .commands
-                .iter()
+                .cmd_iter()
                 .map(|c| c.get_packed_command())
                 .collect::<Vec<_>>();
 

--- a/redis/src/io/tcp.rs
+++ b/redis/src/io/tcp.rs
@@ -35,6 +35,14 @@ impl TcpSettings {
     }
 
     /// Sets the value of the `TCP_NODELAY` option on this socket.
+    ///
+    /// Enabled (`true`) by default, disabling Nagle's algorithm, since Redis
+    /// traffic is strictly request-response: coalescing small writes only adds
+    /// latency (most visibly on multiplexed connections under concurrency,
+    /// where Nagle serializes writes to one per ACK round-trip). Set to `false`
+    /// to re-enable Nagle's algorithm, e.g. on packets-per-second-limited
+    /// cloud instances or metered/WAN links where fewer, larger packets are
+    /// preferable to lower latency.
     pub fn set_nodelay(self, nodelay: bool) -> Self {
         Self { nodelay, ..self }
     }
@@ -77,11 +85,16 @@ impl TcpSettings {
     }
 }
 
-#[allow(clippy::derivable_impls)]
 impl Default for TcpSettings {
     fn default() -> Self {
         Self {
-            nodelay: false,
+            // Enabled by default: RESP is strictly request-response and every
+            // write path in this crate already batches commands into a single
+            // buffer, so Nagle's algorithm only ever adds latency here — under
+            // multiplexed concurrency it serializes writes to one per ACK
+            // round-trip. Use `set_nodelay(false)` to re-enable Nagle (e.g. on
+            // packets-per-second-limited or metered links).
+            nodelay: true,
             #[cfg(not(target_family = "wasm"))]
             keepalive: None,
             linger_time: None,

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -647,9 +647,10 @@ pub use crate::client::Client;
 pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{Arg, Cmd, Iter, cmd, pack_command, pipe};
 pub use crate::commands::{
-    Commands, ControlFlow, CopyOptions, Direction, FlushAllOptions, FlushDbOptions,
+    Aggregate, Commands, ControlFlow, CopyOptions, Direction, FlushAllOptions, FlushDbOptions,
     HashFieldExpirationOptions, HotkeysCommands, LposOptions, MSetOptions, PubSubCommands,
-    ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands, UpdateCheck,
+    ScanOptions, SetOptions, SortedSetAddOptions, SortedSetOperationOptions, TypedCommands,
+    UpdateCheck,
     hotkeys::{
         HOTKEYS_COUNT_MAX, HOTKEYS_COUNT_MIN, HotKeyEntry, HotkeysOptions, HotkeysResponse,
         SlotRange,

--- a/redis/src/parser.rs
+++ b/redis/src/parser.rs
@@ -1,3 +1,8 @@
+// TODO remove this `allow` once `combine` released a fix. Upstream bug: https://github.com/Marwes/combine/issues/372
+#![allow(
+    semicolon_in_expressions_from_macros,
+    reason = "This lint is on in nightly since 2026-07-16, but `combine-4.6.7` violates it in `opaque`. As we cannot decorate directly, we allow it for the whole module for now"
+)]
 use std::{
     io::{self, Read},
     str,

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -324,7 +324,7 @@ fn write_pipeline(rv: &mut Vec<u8>, pipe: &Pipeline, atomic: bool) {
     let write_commands = |rv: &mut Vec<u8>| {
         for idx in 0..pipe.commands.len() {
             let (args, data_start, cursor) = pipe.command_parts(idx);
-            write_command(rv, command_args_iter(&pipe.data, args, data_start), cursor).unwrap();
+            write_command(rv, command_args_iter(&pipe.data, args, data_start), cursor);
         }
     };
 

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -2,17 +2,36 @@
 
 #[cfg(feature = "cache-aio")]
 use crate::cmd::CommandCacheConfig;
-use crate::cmd::{Cmd, cmd, cmd_len};
+use crate::cmd::{Arg, Cmd, CmdRef, args_len, write_command};
 use crate::connection::ConnectionLike;
 use crate::errors::ErrorKind;
-use crate::types::{FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value, from_redis_value};
+use crate::types::{FromRedisValue, RedisResult, ToRedisArgs, Value, from_redis_value};
+
+/// Per-command metadata in a flattened pipeline.
+///
+/// The command's arguments are `args[args_start..next.args_start]` and its argument bytes are
+/// `data[data_start..next.data_start]`, where `next` is the following command's record (or the
+/// buffer ends for the last command). Keeping a small record per command — rather than the
+/// boundary in the hot `args` buffer — allows O(1) jumps between commands while keeping each
+/// `args` entry as small as a standalone `Cmd`'s.
+#[derive(Clone, Debug)]
+pub(crate) struct CommandRecord {
+    pub(crate) args_start: usize,
+    pub(crate) data_start: usize,
+    pub(crate) cursor: Option<u64>,
+    pub(crate) ignored: bool,
+    pub(crate) no_response: bool,
+    #[cfg(feature = "cache-aio")]
+    pub(crate) cache: Option<CommandCacheConfig>,
+}
 
 /// Represents a redis command pipeline.
 #[derive(Clone, Debug)]
 pub struct Pipeline {
-    pub(crate) commands: Vec<Cmd>,
+    pub(crate) data: Vec<u8>,
+    pub(crate) args: Vec<Arg<usize>>,
+    pub(crate) commands: Vec<CommandRecord>,
     pub(crate) transaction_mode: bool,
-    pub(crate) ignored_commands: HashSet<usize>,
     pub(crate) ignore_errors: bool,
 }
 
@@ -40,16 +59,17 @@ pub struct Pipeline {
 impl Pipeline {
     /// Creates an empty pipeline.  For consistency with the `cmd`
     /// api a `pipe` function is provided as alias.
+    ///
+    /// To pre-allocate the internal buffers when you have a size estimate, chain the
+    /// [`reserve_for_commands`](Self::reserve_for_commands),
+    /// [`reserve_for_args`](Self::reserve_for_args), and
+    /// [`reserve_for_data`](Self::reserve_for_data) methods.
     pub fn new() -> Pipeline {
-        Self::with_capacity(0)
-    }
-
-    /// Creates an empty pipeline with pre-allocated capacity.
-    pub fn with_capacity(capacity: usize) -> Pipeline {
         Pipeline {
-            commands: Vec::with_capacity(capacity),
+            data: Vec::new(),
+            args: Vec::new(),
+            commands: Vec::new(),
             transaction_mode: false,
-            ignored_commands: HashSet::new(),
             ignore_errors: false,
         }
     }
@@ -130,7 +150,22 @@ impl Pipeline {
 
     /// Returns the encoded pipeline commands.
     pub fn get_packed_pipeline(&self) -> Vec<u8> {
-        encode_pipeline(&self.commands, self.transaction_mode)
+        encode_pipeline(self, self.transaction_mode)
+    }
+
+    /// Returns the `(args, data_start, cursor)` for the command at `idx`, used by the encoder to
+    /// walk the flat buffers directly.
+    fn command_parts(&self, idx: usize) -> (&[Arg<usize>], usize, u64) {
+        let record = &self.commands[idx];
+        let args_end = self
+            .commands
+            .get(idx + 1)
+            .map_or(self.args.len(), |r| r.args_start);
+        (
+            &self.args[record.args_start..args_end],
+            record.data_start,
+            record.cursor.unwrap_or(0),
+        )
     }
 
     /// Returns the number of commands currently queued by the usr in the pipeline.
@@ -183,17 +218,9 @@ impl Pipeline {
         }
 
         let response = if self.transaction_mode {
-            con.req_packed_commands(
-                &encode_pipeline(&self.commands, true),
-                self.commands.len() + 1,
-                1,
-            )?
+            con.req_packed_commands(&encode_pipeline(self, true), self.len() + 1, 1)?
         } else {
-            con.req_packed_commands(
-                &encode_pipeline(&self.commands, false),
-                0,
-                self.commands.len(),
-            )?
+            con.req_packed_commands(&encode_pipeline(self, false), 0, self.len())?
         };
 
         self.complete_request(response)
@@ -207,11 +234,9 @@ impl Pipeline {
         con: &mut impl crate::aio::ConnectionLike,
     ) -> RedisResult<T> {
         let response = if self.transaction_mode {
-            con.req_packed_commands(self, self.commands.len() + 1, 1)
-                .await?
+            con.req_packed_commands(self, self.len() + 1, 1).await?
         } else {
-            con.req_packed_commands(self, 0, self.commands.len())
-                .await?
+            con.req_packed_commands(self, 0, self.len()).await?
         };
 
         self.complete_request(response)
@@ -258,31 +283,59 @@ impl Pipeline {
     }
 }
 
-fn encode_pipeline(cmds: &[Cmd], atomic: bool) -> Vec<u8> {
+fn encode_pipeline(pipe: &Pipeline, atomic: bool) -> Vec<u8> {
     let mut rv = vec![];
-    write_pipeline(&mut rv, cmds, atomic);
+    write_pipeline(&mut rv, pipe, atomic);
     rv
 }
 
-fn write_pipeline(rv: &mut Vec<u8>, cmds: &[Cmd], atomic: bool) {
-    let cmds_len = cmds.iter().map(cmd_len).sum();
+// Pre-encoded RESP frames for the transaction wrapper. These are constant, so there's no need
+// to build (and allocate) `Cmd`s just to encode them.
+const PACKED_MULTI: &[u8] = b"*1\r\n$5\r\nMULTI\r\n";
+const PACKED_EXEC: &[u8] = b"*1\r\n$4\r\nEXEC\r\n";
+
+/// Builds an iterator over a single command's arguments, slicing directly into the pipeline's
+/// shared `data` buffer using absolute offsets. Unlike [`CmdRef::args_iter`], this needs no
+/// per-argument rebasing, which keeps the hot encode path tight.
+fn command_args_iter<'a>(
+    data: &'a [u8],
+    args: &'a [Arg<usize>],
+    data_start: usize,
+) -> impl Clone + ExactSizeIterator<Item = Arg<&'a [u8]>> {
+    let mut prev = data_start;
+    args.iter().map(move |arg| match *arg {
+        Arg::Simple(end) => {
+            let arg = Arg::Simple(&data[prev..end]);
+            prev = end;
+            arg
+        }
+        Arg::Cursor => Arg::Cursor,
+    })
+}
+
+fn write_pipeline(rv: &mut Vec<u8>, pipe: &Pipeline, atomic: bool) {
+    let cmds_len: usize = (0..pipe.commands.len())
+        .map(|idx| {
+            let (args, data_start, cursor) = pipe.command_parts(idx);
+            args_len(command_args_iter(&pipe.data, args, data_start), cursor)
+        })
+        .sum();
+
+    let write_commands = |rv: &mut Vec<u8>| {
+        for idx in 0..pipe.commands.len() {
+            let (args, data_start, cursor) = pipe.command_parts(idx);
+            write_command(rv, command_args_iter(&pipe.data, args, data_start), cursor).unwrap();
+        }
+    };
 
     if atomic {
-        let multi = cmd("MULTI");
-        let exec = cmd("EXEC");
-        rv.reserve(cmd_len(&multi) + cmd_len(&exec) + cmds_len);
-
-        multi.write_packed_command_preallocated(rv);
-        for cmd in cmds {
-            cmd.write_packed_command_preallocated(rv);
-        }
-        exec.write_packed_command_preallocated(rv);
+        rv.reserve(PACKED_MULTI.len() + PACKED_EXEC.len() + cmds_len);
+        rv.extend_from_slice(PACKED_MULTI);
+        write_commands(rv);
+        rv.extend_from_slice(PACKED_EXEC);
     } else {
         rv.reserve(cmds_len);
-
-        for cmd in cmds {
-            cmd.write_packed_command_preallocated(rv);
-        }
+        write_commands(rv);
     }
 }
 
@@ -290,10 +343,39 @@ fn write_pipeline(rv: &mut Vec<u8>, cmds: &[Cmd], atomic: bool) {
 macro_rules! implement_pipeline_commands {
     ($struct_name:ident) => {
         impl $struct_name {
-            /// Adds a command to the cluster pipeline.
+            /// Pushes a new, empty command record. Subsequent arguments written through
+            /// [`RedisWrite`](crate::RedisWrite) belong to it until the next command starts.
+            #[inline]
+            fn start_command(&mut self) {
+                self.commands.push($crate::pipeline::CommandRecord {
+                    args_start: self.args.len(),
+                    data_start: self.data.len(),
+                    cursor: None,
+                    ignored: false,
+                    no_response: false,
+                    #[cfg(feature = "cache-aio")]
+                    cache: None,
+                });
+            }
+
+            /// Adds a command to the pipeline.
             #[inline]
             pub fn add_command(&mut self, cmd: Cmd) -> &mut Self {
-                self.commands.push(cmd);
+                self.start_command();
+                for arg in cmd.args_iter() {
+                    match arg {
+                        Arg::Simple(bytes) => $crate::types::RedisWrite::write_arg(self, bytes),
+                        Arg::Cursor => self.args.push(Arg::Cursor),
+                    }
+                }
+                if let Some(record) = self.commands.last_mut() {
+                    record.cursor = cmd.cursor_value();
+                    record.no_response = cmd.is_no_response();
+                    #[cfg(feature = "cache-aio")]
+                    {
+                        record.cache = cmd.get_cache_config().clone();
+                    }
+                }
                 self
             }
 
@@ -301,12 +383,62 @@ macro_rules! implement_pipeline_commands {
             /// available to add more arguments to that command.
             #[inline]
             pub fn cmd(&mut self, name: &str) -> &mut Self {
-                self.add_command(cmd(name))
+                self.start_command();
+                $crate::types::RedisWrite::write_arg(self, name.as_bytes());
+                self
             }
 
             /// Returns an iterator over all the commands currently in this pipeline
-            pub fn cmd_iter(&self) -> impl Iterator<Item = &Cmd> {
-                self.commands.iter()
+            pub fn cmd_iter(&self) -> impl Iterator<Item = CmdRef<'_>> {
+                (0..self.commands.len()).map(move |idx| self.command_ref(idx))
+            }
+
+            /// Reserves capacity for at least `additional` more commands.
+            ///
+            /// This is a hint for pre-allocation; the pipeline grows automatically as needed.
+            #[inline]
+            pub fn reserve_for_commands(&mut self, additional: usize) -> &mut Self {
+                self.commands.reserve(additional);
+                self
+            }
+
+            /// Reserves capacity for at least `additional` more arguments, counted across all
+            /// commands.
+            ///
+            /// This is a hint for pre-allocation; the pipeline grows automatically as needed.
+            #[inline]
+            pub fn reserve_for_args(&mut self, additional: usize) -> &mut Self {
+                self.args.reserve(additional);
+                self
+            }
+
+            /// Reserves capacity for at least `additional` more argument bytes, counted across all
+            /// commands.
+            ///
+            /// This is a hint for pre-allocation; the pipeline grows automatically as needed.
+            #[inline]
+            pub fn reserve_for_data(&mut self, additional: usize) -> &mut Self {
+                self.data.reserve(additional);
+                self
+            }
+
+            /// Builds a borrowed view of the command at `idx`.
+            #[inline]
+            fn command_ref(&self, idx: usize) -> CmdRef<'_> {
+                let record = &self.commands[idx];
+                let next = self.commands.get(idx + 1);
+                let args_end = next.map_or(self.args.len(), |r| r.args_start);
+                let data_end = next.map_or(self.data.len(), |r| r.data_start);
+                CmdRef::new(
+                    &self.data[record.data_start..data_end],
+                    &self.args[record.args_start..args_end],
+                    record.data_start,
+                    record.cursor,
+                    record.no_response,
+                    record.ignored,
+                    #[cfg(feature = "cache-aio")]
+                    &record.cache,
+                )
             }
 
             /// Instructs the pipeline to ignore the return value of this command.
@@ -318,10 +450,9 @@ macro_rules! implement_pipeline_commands {
             /// so that the user could retrace which command failed.
             #[inline]
             pub fn ignore(&mut self) -> &mut Self {
-                match self.commands.len() {
-                    0 => true,
-                    x => self.ignored_commands.insert(x - 1),
-                };
+                if let Some(record) = self.commands.last_mut() {
+                    record.ignored = true;
+                }
                 self
             }
 
@@ -331,10 +462,8 @@ macro_rules! implement_pipeline_commands {
             /// Note that this function fails the task if executed on an empty pipeline.
             #[inline]
             pub fn arg<T: ToRedisArgs>(&mut self, arg: T) -> &mut Self {
-                {
-                    let cmd = self.get_last_command();
-                    cmd.arg(arg);
-                }
+                assert!(!self.commands.is_empty(), "No command on stack");
+                arg.write_redis_args(self);
                 self
             }
 
@@ -344,30 +473,26 @@ macro_rules! implement_pipeline_commands {
             /// amount of memory released/reallocated.
             #[inline]
             pub fn clear(&mut self) {
+                self.data.clear();
+                self.args.clear();
                 self.commands.clear();
-                self.ignored_commands.clear();
-            }
-
-            #[inline]
-            fn get_last_command(&mut self) -> &mut Cmd {
-                let idx = match self.commands.len() {
-                    0 => panic!("No command on stack"),
-                    x => x - 1,
-                };
-                &mut self.commands[idx]
             }
 
             fn filter_ignored_results(&self, resp: Vec<Value>) -> Vec<Value> {
                 // Common case: nothing was `.ignore()`d, so every result is kept.
                 // Return the response as-is instead of rebuilding the whole
                 // `Vec<Value>` (which would reallocate and move every element).
-                if self.ignored_commands.is_empty() {
+                if !self.commands.iter().any(|command| command.ignored) {
                     return resp;
                 }
                 resp.into_iter()
                     .enumerate()
                     .filter_map(|(index, result)| {
-                        (!self.ignored_commands.contains(&index)).then(|| result)
+                        let ignored = self
+                            .commands
+                            .get(index)
+                            .is_some_and(|record| record.ignored);
+                        (!ignored).then_some(result)
                     })
                     .collect()
             }
@@ -398,6 +523,51 @@ macro_rules! implement_pipeline_commands {
             }
         }
 
+        impl $crate::types::RedisWrite for $struct_name {
+            fn write_arg(&mut self, arg: &[u8]) {
+                self.data.extend_from_slice(arg);
+                self.args.push(Arg::Simple(self.data.len()));
+            }
+
+            fn write_arg_fmt(&mut self, arg: impl std::fmt::Display) {
+                use std::io::Write as _;
+                write!(self.data, "{arg}").unwrap();
+                self.args.push(Arg::Simple(self.data.len()));
+            }
+
+            fn writer_for_next_arg(&mut self) -> impl std::io::Write + '_ {
+                struct PipelineArgGuard<'a>(&'a mut $struct_name);
+                impl Drop for PipelineArgGuard<'_> {
+                    fn drop(&mut self) {
+                        self.0.args.push(Arg::Simple(self.0.data.len()));
+                    }
+                }
+                impl std::io::Write for PipelineArgGuard<'_> {
+                    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                        self.0.data.extend_from_slice(buf);
+                        Ok(buf.len())
+                    }
+
+                    fn flush(&mut self) -> std::io::Result<()> {
+                        Ok(())
+                    }
+                }
+
+                PipelineArgGuard(self)
+            }
+
+            fn reserve_space_for_args(&mut self, additional: impl IntoIterator<Item = usize>) {
+                let mut capacity = 0;
+                let mut args = 0;
+                for add in additional {
+                    capacity += add;
+                    args += 1;
+                }
+                self.data.reserve(capacity);
+                self.args.reserve(args);
+            }
+        }
+
         impl Default for $struct_name {
             fn default() -> Self {
                 Self::new()
@@ -414,14 +584,39 @@ impl Pipeline {
     #[cfg(feature = "cache-aio")]
     #[cfg_attr(docsrs, doc(cfg(feature = "cache-aio")))]
     pub fn set_cache_config(&mut self, command_cache_config: CommandCacheConfig) -> &mut Self {
-        let cmd = self.get_last_command();
-        cmd.set_cache_config(command_cache_config);
+        if let Some(record) = self.commands.last_mut() {
+            record.cache = Some(command_cache_config);
+        }
+        self
+    }
+
+    /// Appends a command from a borrowed [`CmdRef`] without allocating an intermediate [`Cmd`].
+    ///
+    /// This is the borrowing counterpart of [`add_command`](Self::add_command), used by the
+    /// caching layer to repack commands it inspected as `CmdRef`s.
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn add_command_ref(&mut self, cmd: CmdRef<'_>) -> &mut Self {
+        self.start_command();
+        for arg in cmd.args_iter() {
+            match arg {
+                Arg::Simple(bytes) => crate::types::RedisWrite::write_arg(self, bytes),
+                Arg::Cursor => self.args.push(Arg::Cursor),
+            }
+        }
+        if let Some(record) = self.commands.last_mut() {
+            record.cursor = cmd.cursor();
+            record.no_response = cmd.is_no_response();
+            record.cache = cmd.get_cache_config().clone();
+        }
         self
     }
 
     #[cfg(feature = "cluster-async")]
     pub(crate) fn into_cmd_iter(self) -> impl Iterator<Item = Cmd> {
-        self.commands.into_iter()
+        self.cmd_iter()
+            .map(|cmd| cmd.to_cmd())
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }
 

--- a/redis/src/subscription_tracker.rs
+++ b/redis/src/subscription_tracker.rs
@@ -3,7 +3,7 @@
 use core::str;
 use std::collections::HashSet;
 
-use crate::{Arg, Cmd, Pipeline};
+use crate::{Arg, Pipeline};
 
 #[derive(Default)]
 pub(crate) struct SubscriptionTracker {
@@ -36,10 +36,9 @@ impl SubscriptionAction {
 }
 
 impl SubscriptionTracker {
-    pub(crate) fn to_request(
-        cmd: &Cmd,
+    pub(crate) fn to_request<'a>(
+        mut args_iter: impl Iterator<Item = Arg<&'a [u8]>>,
     ) -> Option<(SubscriptionAction, impl Iterator<Item = Vec<u8>>)> {
-        let mut args_iter = cmd.args_iter();
         let first_arg = args_iter.next()?;
 
         let first_arg = match first_arg {
@@ -100,8 +99,8 @@ impl SubscriptionTracker {
     }
 
     #[cfg(test)]
-    fn update_with_cmd<'a>(&'a mut self, cmd: &'a Cmd) {
-        if let Some((action, args)) = Self::to_request(cmd) {
+    fn update_with_cmd<'a>(&'a mut self, cmd: &'a crate::Cmd) {
+        if let Some((action, args)) = Self::to_request(cmd.args_iter()) {
             self.update_with_request(action, args);
         }
     }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -52,22 +52,23 @@ impl ToRedisArgs for SetExpiry {
     where
         W: ?Sized + RedisWrite,
     {
+        let mut buf = ::itoa::Buffer::new();
         match self {
             SetExpiry::EX(secs) => {
                 out.write_arg(b"EX");
-                out.write_arg(format!("{secs}").as_bytes());
+                out.write_arg(buf.format(*secs).as_bytes());
             }
             SetExpiry::PX(millis) => {
                 out.write_arg(b"PX");
-                out.write_arg(format!("{millis}").as_bytes());
+                out.write_arg(buf.format(*millis).as_bytes());
             }
             SetExpiry::EXAT(unix_time) => {
                 out.write_arg(b"EXAT");
-                out.write_arg(format!("{unix_time}").as_bytes());
+                out.write_arg(buf.format(*unix_time).as_bytes());
             }
             SetExpiry::PXAT(unix_time) => {
                 out.write_arg(b"PXAT");
-                out.write_arg(format!("{unix_time}").as_bytes());
+                out.write_arg(buf.format(*unix_time).as_bytes());
             }
             SetExpiry::KEEPTTL => {
                 out.write_arg(b"KEEPTTL");

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1,11 +1,11 @@
 use crate::errors::ParsingError;
 #[cfg(feature = "ahash")]
-pub(crate) use ahash::{AHashMap as HashMap, AHashSet as HashSet};
+pub(crate) use ahash::AHashMap as HashMap;
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
 use std::borrow::Cow;
 #[cfg(not(feature = "ahash"))]
-pub(crate) use std::collections::{HashMap, HashSet};
+pub(crate) use std::collections::HashMap;
 use std::default::Default;
 use std::ffi::CString;
 use std::fmt;

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -230,7 +230,7 @@ impl aio::ConnectionLike for MockConnection {
         Box::pin(future::ready(
             pipeline
                 .cmd_iter()
-                .map(|cmd| self.execute_cmd(cmd))
+                .map(|cmd| self.execute_cmd(&cmd.to_cmd()))
                 .collect(),
         ))
     }

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -9,7 +9,7 @@ use redis::{
     cluster::{self, ClusterClient, ClusterClientBuilder},
 };
 
-use redis::{IntoConnectionInfo, RedisResult, Value};
+use redis::{IntoConnectionInfo, RedisError, RedisResult, Value};
 
 #[cfg(feature = "cluster-async")]
 use redis::{RedisFuture, aio, cluster_async};
@@ -213,6 +213,13 @@ pub fn respond_startup_with_replica_using_config(
     } else {
         Ok(())
     }
+}
+
+pub fn broken_pipe_error() -> RedisError {
+    RedisError::from(std::io::Error::new(
+        std::io::ErrorKind::BrokenPipe,
+        "mock-io-error",
+    ))
 }
 
 #[cfg(feature = "cluster-async")]

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -246,17 +246,14 @@ impl TestContext {
         tls_files: Option<TlsFilePaths>,
         cert_auth_field: Option<&str>,
     ) -> Self {
-        let server = RedisServer::new_with_addr_tls_modules_and_spawner(
+        let server = RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
             addr,
             None,
             tls_files,
             mtls_enabled,
             cert_auth_field,
             modules,
-            |cmd| {
-                cmd.spawn()
-                    .unwrap_or_else(|err| panic!("Failed to run {cmd:?}: {err}"))
-            },
+            |_cmd| {},
         );
 
         let client =

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -12,6 +12,7 @@ pub const REDIS_CE_8_0: Component = ("redis", (8, 0, 0));
 pub const REDIS_CE_8_2: Component = ("redis", (8, 1, 240));
 pub const REDIS_CE_8_4: Component = ("redis", (8, 3, 224));
 pub const REDIS_CE_8_6: Component = ("redis", (8, 6, 0));
+pub const REDIS_CE_8_8: Component = ("redis", (8, 8, 0));
 
 pub const REDIS_BLOOM_ANY: Component = ("redis:bf", (0, 0, 0));
 

--- a/redis/tests/test_acl.rs
+++ b/redis/tests/test_acl.rs
@@ -621,7 +621,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn authentication_with_mock_streaming_credentials_provider() {
+    async fn test_authentication_with_mock_streaming_credentials_provider() {
         init_logger();
         let ctx = TestContext::new();
         // Set up a Redis user that expects a JWT token as password
@@ -761,7 +761,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn authentication_error_handling_with_mock_streaming_credentials_provider() {
+    async fn test_authentication_error_handling_with_mock_streaming_credentials_provider() {
         init_logger();
         let ctx = TestContext::new();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
@@ -820,7 +820,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn multiple_connections_from_one_client_sharing_a_single_credentials_provider() {
+    async fn test_multiple_connections_from_one_client_sharing_a_single_credentials_provider() {
         init_logger();
         let ctx = TestContext::new();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
@@ -887,7 +887,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn multiple_clients_sharing_a_single_credentials_provider() {
+    async fn test_multiple_clients_sharing_a_single_credentials_provider() {
         init_logger();
         let ctx1 = TestContext::new();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
@@ -958,7 +958,7 @@ mod token_based_authentication_acl_tests {
     /// 4. Admin invalidates Alice via ACL DELUSER
     /// 5. The server rejects the next command — proving we rely on the server for auth enforcement
     #[async_test]
-    async fn server_rejects_after_user_invalidated() {
+    async fn test_server_rejects_after_user_invalidated() {
         init_logger();
         let ctx = TestContext::new();
 
@@ -1051,7 +1051,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_authentication_with_mock_streaming_credentials_provider() {
+        async fn test_cluster_authentication_with_mock_streaming_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1089,7 +1089,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_token_rotation_with_mock_streaming_credentials_provider() {
+        async fn test_cluster_token_rotation_with_mock_streaming_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1119,7 +1119,8 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_authentication_error_handling_with_mock_streaming_credentials_provider() {
+        async fn test_cluster_authentication_error_handling_with_mock_streaming_credentials_provider()
+         {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1155,7 +1156,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_multiple_connections_sharing_a_single_credentials_provider() {
+        async fn test_cluster_multiple_connections_sharing_a_single_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1197,7 +1198,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_multiple_clients_sharing_a_single_credentials_provider() {
+        async fn test_cluster_multiple_clients_sharing_a_single_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new();
 
@@ -1266,7 +1267,7 @@ mod token_based_authentication_acl_tests {
         /// 4. Admin invalidates Alice via ACL DELUSER on all nodes
         /// 5. The server rejects the next command — proving we rely on the server for auth enforcement
         #[async_test]
-        async fn cluster_server_rejects_after_user_invalidated() {
+        async fn test_cluster_server_rejects_after_user_invalidated() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -56,7 +56,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn args(mut con: impl ConnectionLike) {
+    async fn test_args(mut con: impl ConnectionLike) {
         redis::cmd("SET")
             .arg("key1")
             .arg(b"foo")
@@ -76,7 +76,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn no_response_skips_response_even_on_error(mut con: impl ConnectionLike) {
+    async fn test_no_response_skips_response_even_on_error(mut con: impl ConnectionLike) {
         redis::cmd("SET")
             .arg("key")
             .arg(b"foo")
@@ -155,7 +155,22 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn can_authenticate_with_username_and_password() {
+    async fn test_set_write_backpressure_boundary_does_not_break_connection() {
+        let ctx = TestContext::new();
+        let config =
+            redis::AsyncConnectionConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        let mut conn = ctx
+            .client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await
+            .unwrap();
+        let _: () = conn.set("key", "value").await.unwrap();
+        let result: String = conn.get("key").await.unwrap();
+        assert_eq!(result, "value");
+    }
+
+    #[async_test]
+    async fn test_can_authenticate_with_username_and_password() {
         let ctx = TestContext::new();
         let mut con = ctx.async_connection().await.unwrap();
 
@@ -192,7 +207,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn nice_hash_api(mut connection: impl AsyncCommands) {
+    async fn test_nice_hash_api(mut connection: impl AsyncCommands) {
         assert_eq!(
             connection
                 .hset_multiple("my_hash", &[("f1", 1), ("f2", 2), ("f3", 4), ("f4", 8)])
@@ -209,7 +224,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn nice_hash_api_in_pipe(mut connection: impl AsyncCommands) {
+    async fn test_nice_hash_api_in_pipe(mut connection: impl AsyncCommands) {
         assert_eq!(
             connection
                 .hset_multiple("my_hash", &[("f1", 1), ("f2", 2), ("f3", 4), ("f4", 8)])
@@ -230,7 +245,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn dont_panic_on_closed_multiplexed_connection() {
+    async fn test_dont_panic_on_closed_multiplexed_connection() {
         let ctx = TestContext::new();
         let client = ctx.client.clone();
         let connect = client.get_multiplexed_async_connection();
@@ -259,7 +274,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_transaction(mut con: impl ConnectionLike) {
+    async fn test_pipeline_transaction(mut con: impl ConnectionLike) {
         let mut pipe = redis::pipe();
         pipe.atomic()
             .cmd("SET")
@@ -282,7 +297,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn client_tracking_doesnt_block_execution(mut con: impl AsyncCommands) {
+    async fn test_client_tracking_doesnt_block_execution(mut con: impl AsyncCommands) {
         //It checks if the library distinguish a push-type message from the others and continues its normal operation.
 
         let mut pipe = redis::pipe();
@@ -303,7 +318,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_transaction_with_errors(mut con: impl AsyncCommands) {
+    async fn test_pipeline_transaction_with_errors(mut con: impl AsyncCommands) {
         con.set::<_, _, ()>("x", 42).await.unwrap();
 
         // Make Redis a replica of a nonexistent master, thereby making it read-only.
@@ -340,7 +355,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "json")]
-    async fn module_json_and_pipeline_transaction_with_ignore_errors() {
+    async fn test_module_json_and_pipeline_transaction_with_ignore_errors() {
         let ctx = TestContext::with_modules(&[Module::Json]);
         let mut con = ctx.async_connection().await.unwrap();
         con.set::<_, _, ()>("x", 42).await.unwrap();
@@ -391,7 +406,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_with_ignore_errors(mut con: impl AsyncCommands) {
+    async fn test_pipeline_with_ignore_errors(mut con: impl AsyncCommands) {
         con.set::<_, _, ()>("x", 42).await.unwrap();
 
         let mut pipeline = redis::pipe();
@@ -420,7 +435,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_returns_server_errors(mut con: impl AsyncCommands) {
+    async fn test_pipeline_returns_server_errors(mut con: impl AsyncCommands) {
         let mut pipe = redis::pipe();
         pipe.set("x", "x-value")
             .ignore()
@@ -468,7 +483,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipe_over_multiplexed_connection(mut con: impl ConnectionLike) {
+    async fn test_pipe_over_multiplexed_connection(mut con: impl ConnectionLike) {
         let mut pipe = pipe();
         pipe.zrange("zset", 0, 0);
         pipe.zrange("zset", 0, 0);
@@ -479,13 +494,13 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn running_multiple_commands(con: impl AsyncCommands + Clone) {
+    async fn test_running_multiple_commands(con: impl AsyncCommands + Clone) {
         let cmds = (0..100).map(move |i| test_cmd(con.clone(), i));
         future::join_all(cmds).await;
     }
 
     #[async_test]
-    async fn transaction_multiplexed_connection(con: impl ConnectionLike + Clone) {
+    async fn test_async_transaction(con: impl ConnectionLike + Clone) {
         let cmds = (0..100).map(move |i| {
             let mut con = con.clone();
             async move {
@@ -522,7 +537,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_scanning(mut con: impl ConnectionLike + Send) {
+    async fn test_async_scanning(mut con: impl ConnectionLike + Send) {
         let mut unseen = std::collections::HashSet::new();
 
         for x in 0..1000 {
@@ -554,7 +569,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_scanning_iterative(mut con: impl ConnectionLike + Send) {
+    async fn test_async_scanning_iterative(mut con: impl ConnectionLike + Send) {
         let mut unseen = std::collections::HashSet::new();
 
         for x in 0..1000 {
@@ -590,7 +605,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_scanning_stream(mut con: impl ConnectionLike + Sync + Send) {
+    async fn test_async_scanning_stream(mut con: impl ConnectionLike + Sync + Send) {
         let mut unseen = std::collections::HashSet::new();
 
         for x in 0..1000 {
@@ -626,7 +641,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn response_timeout_multiplexed_connection() {
+    async fn test_response_timeout_multiplexed_connection() {
         let ctx = TestContext::new();
 
         let mut connection = ctx.async_connection().await.unwrap();
@@ -640,7 +655,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "script")]
-    async fn script(mut con: impl ConnectionLike) {
+    async fn test_script(mut con: impl ConnectionLike) {
         // Note this test runs both scripts twice to test when they have already been loaded
         // into Redis and when they need to be loaded in
         let script1 = redis::Script::new("return redis.call('SET', KEYS[1], ARGV[1])");
@@ -670,7 +685,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "script")]
-    async fn script_load(mut con: impl ConnectionLike) {
+    async fn test_script_load(mut con: impl ConnectionLike) {
         let script = redis::Script::new("return 'Hello World'");
 
         let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
@@ -679,7 +694,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "script")]
-    async fn script_returning_complex_type(mut con: impl ConnectionLike) {
+    async fn test_script_returning_complex_type(mut con: impl ConnectionLike) {
         redis::Script::new("return {1, ARGV[1], true}")
             .arg("hello")
             .invoke_async(&mut con)
@@ -696,7 +711,7 @@ mod basic_async {
     // Allowing `let ()` as `query_async` requires the type it converts the result to.
     #[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
     #[async_test]
-    async fn io_error_on_kill_issue_320() {
+    async fn test_io_error_on_kill_issue_320() {
         let ctx = TestContext::new();
 
         let mut conn_to_kill = ctx.async_connection().await.unwrap();
@@ -716,7 +731,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn invalid_password_issue_343() {
+    async fn test_invalid_password_issue_343() {
         let ctx = TestContext::new();
 
         let redis = RedisConnectionInfo::default().set_password("asdcasc");
@@ -743,7 +758,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn scan_with_options_works(mut con: impl AsyncCommands) {
+    async fn test_scan_with_options_works(mut con: impl AsyncCommands) {
         for i in 0..20usize {
             let _: () = con.append(format!("test/{i}"), i).await.unwrap();
             let _: () = con.append(format!("other/{i}"), i).await.unwrap();
@@ -772,7 +787,7 @@ mod basic_async {
     // Test issue of Stream trait blocking if we try to iterate more than 10 items
     // https://github.com/mitsuhiko/redis-rs/issues/537 and https://github.com/mitsuhiko/redis-rs/issues/583
     #[async_test]
-    async fn issue_stream_blocks(mut con: impl AsyncCommands) {
+    async fn test_issue_stream_blocks(mut con: impl AsyncCommands) {
         for i in 0..20usize {
             let _: () = con.append(format!("test/{i}"), i).await.unwrap();
         }
@@ -789,7 +804,7 @@ mod basic_async {
     // Test issue of AsyncCommands::scan returning the wrong number of keys
     // https://github.com/redis-rs/redis-rs/issues/759
     #[async_test]
-    async fn issue_async_commands_scan_broken(mut con: impl AsyncCommands) {
+    async fn test_issue_async_commands_scan_broken(mut con: impl AsyncCommands) {
         let mut keys: Vec<String> = (0..100).map(|k| format!("async-key{k}")).collect();
         keys.sort();
         for key in &keys {
@@ -809,7 +824,7 @@ mod basic_async {
         use super::*;
 
         #[async_test]
-        async fn pub_sub_subscription() {
+        async fn test_pub_sub_subscription() {
             let ctx = TestContext::new();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
@@ -831,7 +846,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_subscription_to_multiple_channels() {
+        async fn test_pub_sub_subscription_to_multiple_channels() {
             let ctx = TestContext::new();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
@@ -854,7 +869,7 @@ mod basic_async {
         // Test issue of AsyncCommands::scan not returning keys because wrong assumptions about the key type were made
         // https://github.com/redis-rs/redis-rs/issues/1309
         #[async_test]
-        async fn issue_async_commands_scan_finishing_prematurely(mut con: impl AsyncCommands) {
+        async fn test_issue_async_commands_scan_finishing_prematurely(mut con: impl AsyncCommands) {
             const PREFIX: &str = "async-key";
             const NUM_KEYS: usize = 100;
 
@@ -912,7 +927,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_unsubscription() {
+        async fn test_pub_sub_unsubscription() {
             const SUBSCRIPTION_KEY: &str = "phonewave-pub-sub-unsubscription";
 
             let ctx = TestContext::new();
@@ -933,7 +948,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_receive_messages_while_sending_requests_from_split_pub_sub() {
+        async fn test_can_receive_messages_while_sending_requests_from_split_pub_sub() {
             let ctx = TestContext::new();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
@@ -953,7 +968,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_send_ping_on_split_pubsub() {
+        async fn test_can_send_ping_on_split_pubsub() {
             let ctx = TestContext::new();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
@@ -996,7 +1011,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_receive_messages_from_split_pub_sub_after_sink_was_dropped() {
+        async fn test_can_receive_messages_from_split_pub_sub_after_sink_was_dropped() {
             let ctx = TestContext::new();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
@@ -1017,7 +1032,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_receive_messages_from_split_pub_sub_after_into_on_message() {
+        async fn test_can_receive_messages_from_split_pub_sub_after_into_on_message() {
             let ctx = TestContext::new();
 
             let mut pubsub = ctx.async_pubsub().await.unwrap();
@@ -1040,7 +1055,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn cannot_subscribe_on_split_pub_sub_after_stream_was_dropped() {
+        async fn test_cannot_subscribe_on_split_pub_sub_after_stream_was_dropped() {
             let ctx = TestContext::new();
 
             let (mut sink, stream) = ctx.async_pubsub().await.unwrap().split();
@@ -1050,7 +1065,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn automatic_unsubscription() {
+        async fn test_automatic_unsubscription() {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription";
 
             let ctx = TestContext::new();
@@ -1080,7 +1095,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn automatic_unsubscription_on_split() {
+        async fn test_automatic_unsubscription_on_split() {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription-on-split";
 
             let ctx = TestContext::new();
@@ -1124,7 +1139,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pipe_errors_do_not_affect_subsequent_commands(mut conn: impl AsyncCommands) {
+        async fn test_pipe_errors_do_not_affect_subsequent_commands(mut conn: impl AsyncCommands) {
             conn.lpush::<&str, &str, ()>("key", "value").await.unwrap();
 
             redis::pipe()
@@ -1139,7 +1154,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn multiplexed_pub_sub_subscribe_on_multiple_channels() {
+        async fn test_multiplexed_pub_sub_subscribe_on_multiple_channels() {
             let ctx = TestContext::new();
             if !ctx.protocol.supports_resp3() {
                 return;
@@ -1169,7 +1184,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn non_transaction_errors_do_not_affect_other_results_in_pipeline(
+        async fn test_non_transaction_errors_do_not_affect_other_results_in_pipeline(
             mut conn: impl AsyncCommands,
         ) {
             conn.lpush::<&str, &str, ()>("key", "value").await.unwrap();
@@ -1190,7 +1205,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_multiple() {
+        async fn test_pub_sub_multiple() {
             let ctx = TestContext::new();
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1254,7 +1269,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_requires_resp3() {
+        async fn test_pub_sub_requires_resp3() {
             if use_protocol().supports_resp3() {
                 return;
             }
@@ -1270,7 +1285,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn push_sender_send_on_disconnect() {
+        async fn test_push_sender_send_on_disconnect() {
             let ctx = TestContext::new();
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1292,7 +1307,7 @@ mod basic_async {
 
         #[cfg(feature = "connection-manager")]
         #[async_test]
-        async fn manager_should_resubscribe_to_pubsub_channels_after_disconnect() {
+        async fn test_manager_should_resubscribe_to_pubsub_channels_after_disconnect() {
             let ctx = TestContext::new();
             if !ctx.protocol.supports_resp3() {
                 return;
@@ -1387,7 +1402,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_basic_pipe_with_parsing_error(mut conn: impl ConnectionLike) {
+    async fn test_async_basic_pipe_with_parsing_error(mut conn: impl ConnectionLike) {
         // Tests a specific case involving repeated errors in transactions.
 
         // create a transaction where 2 errors are returned.
@@ -1417,7 +1432,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "connection-manager")]
-    async fn connection_manager_reconnect_after_delay() {
+    async fn test_connection_manager_reconnect_after_delay() {
         let max_delay_between_attempts = Duration::from_millis(2);
         let mut config = redis::aio::ConnectionManagerConfig::new()
             .set_exponent_base(10000.0)
@@ -1440,8 +1455,11 @@ mod basic_async {
             redis::aio::ConnectionManager::new_with_config(ctx.client.clone(), config)
                 .await
                 .unwrap();
+
+        // Store the server's address and kill the server
         let addr = ctx.server.client_addr().clone();
         drop(ctx);
+
         let result: RedisResult<redis::Value> = manager.set("foo", "bar").await;
         // we expect a connection failure error.
         assert!(result.unwrap_err().is_unrecoverable_error());
@@ -1449,7 +1467,8 @@ mod basic_async {
             assert_eq!(rx.recv().await.unwrap().kind, PushKind::Disconnection);
         }
 
-        let _server = redis_test::server::RedisServer::new_with_addr_and_modules(addr, &[], false);
+        // Start a new server, re-using the previous address
+        let _ctx = TestContext::new_with_addr(addr);
 
         for _ in 0..5 {
             let Ok(result) = manager.set::<_, _, Value>("foo", "bar").await else {
@@ -1467,7 +1486,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn manager_should_reconnect_without_actions_if_resp3_is_set() {
+    async fn test_manager_should_reconnect_without_actions_if_resp3_is_set() {
         let ctx = TestContext::new();
         if !ctx.protocol.supports_resp3() {
             return;
@@ -1495,7 +1514,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn manager_should_completely_disconnect_when_drop() {
+    async fn test_manager_should_completely_disconnect_when_drop() {
         let ctx = TestContext::new();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1536,7 +1555,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error()
+    async fn test_manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error()
      {
         let ctx = TestContext::new();
         if !ctx.protocol.supports_resp3() {
@@ -1579,7 +1598,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn multiplexed_connection_kills_connection_on_drop_even_when_blocking() {
+    async fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking() {
         let ctx = TestContext::new();
 
         let mut conn = ctx.async_connection().await.unwrap();
@@ -1616,7 +1635,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn monitor() {
+    async fn test_monitor() {
         let ctx = TestContext::new();
 
         let mut conn = ctx.async_connection().await.unwrap();
@@ -1712,7 +1731,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "connection-manager")]
-    async fn resp3_pushes_connection_manager() {
+    async fn test_resp3_pushes_connection_manager() {
         let ctx = TestContext::new();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1738,7 +1757,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn select_db() {
+    async fn test_select_db() {
         let ctx = TestContext::new();
         let redis = redis_settings().set_db(5);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1755,7 +1774,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn multiplexed_connection_send_single_disconnect_on_connection_failure() {
+    async fn test_multiplexed_connection_send_single_disconnect_on_connection_failure() {
         let mut ctx = TestContext::new();
         if !ctx.protocol.supports_resp3() {
             return;
@@ -1778,7 +1797,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn fail_on_empty_command() {
+    async fn test_fail_on_empty_command() {
         let ctx = TestContext::new();
         let mut connection = ctx.async_connection().await.unwrap();
 
@@ -1811,7 +1830,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn simple_case_success(mut con: impl AsyncCommands + Clone) {
+        async fn test_simple_case_success(mut con: impl AsyncCommands + Clone) {
             let res: Vec<usize> = redis::aio::transaction_async(
                 con.clone(),
                 &["x", "y"],
@@ -1834,7 +1853,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_watch() {
+        async fn test_transaction_should_retry_on_watch() {
             let ctx = TestContext::new();
             let con1 = ctx.async_connection().await.unwrap();
             let mut con2 = ctx.async_connection().await.unwrap();
@@ -1880,7 +1899,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_none_from_closure() {
+        async fn test_transaction_should_retry_on_none_from_closure() {
             let ctx = TestContext::new();
             let con = ctx.async_connection().await.unwrap();
 
@@ -1907,7 +1926,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn transaction_abort_if_internal_function_returns_error() {
+        async fn test_transaction_abort_if_internal_function_returns_error() {
             let ctx = TestContext::new();
             let con = ctx.async_connection().await.unwrap();
             let attempts = Arc::new(AtomicUsize::new(0));
@@ -1949,7 +1968,7 @@ mod basic_async {
         use super::*;
 
         #[async_test]
-        async fn lazy_connection_manager_can_be_created_synchronously() {
+        async fn test_lazy_connection_manager_can_be_created_synchronously() {
             let ctx = TestContext::new();
 
             let config = redis::aio::ConnectionManagerConfig::new()
@@ -1965,7 +1984,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn lazy_connection_manager_reconnects_after_disconnect() {
+        async fn test_lazy_connection_manager_reconnects_after_disconnect() {
             let ctx = TestContext::new();
 
             let max_delay_between_attempts = Duration::from_millis(2);
@@ -1996,7 +2015,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn lazy_connection_manager_can_be_cloned_before_sending() {
+        async fn test_lazy_connection_manager_can_be_cloned_before_sending() {
             let ctx = TestContext::new();
 
             let config = redis::aio::ConnectionManagerConfig::new();
@@ -2015,7 +2034,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn lazy_connection_manager_with_resp3_push() {
+        async fn test_lazy_connection_manager_with_resp3_push() {
             let ctx = TestContext::new();
             if !ctx.protocol.supports_resp3() {
                 return;

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -2332,146 +2332,438 @@ mod basic {
     }
 
     #[test]
-    fn test_zinterstore_options() {
+    fn test_zinterstore_zunionstore() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
+        // Shared members (one, two) have different scores in each set so that
+        // SUM, MIN and MAX each produce distinct, obvious results.
         con.zadd_multiple("zset1", &[(1, "one"), (2, "two"), (4, "four")])
             .unwrap();
-        con.zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
+        con.zadd_multiple("zset2", &[(5, "one"), (6, "two"), (3, "three")])
             .unwrap();
 
-        // zinterstore with SUM aggregation (default)
-        assert_eq!(
-            con.zinterstore(
-                "out",
-                &["zset1", "zset2"],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(2)
-        );
+        let sum = || SortedSetOperationOptions::default();
+        let min = || SortedSetOperationOptions::default().aggregate(Aggregate::Min);
+        let max = || SortedSetOperationOptions::default().aggregate(Aggregate::Max);
 
-        // zinterstore with weights
-        assert_eq!(
-            con.zinterstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(2)
-        );
-
+        // ZINTERSTORE (intersection = {one, two}).
+        // Without weights the aggregators combine the raw scores:
+        // SUM one = 1 + 5, two = 2 + 6; MIN/MAX keep the smaller/larger score.
+        assert_eq!(con.zinterstore("out", &["zset1", "zset2"], sum()), Ok(2));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
-            Ok(vec![("one".to_string(), 5.0), ("two".to_string(), 10.0)])
+            Ok(vec![("one".to_string(), 6.0), ("two".to_string(), 8.0)])
         );
-
-        // zinterstore_with_weights with MIN aggregation
-        assert_eq!(
-            con.zinterstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Min)
-            ),
-            Ok(2)
-        );
-
+        assert_eq!(con.zinterstore("out", &["zset1", "zset2"], min()), Ok(2));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
-            Ok(vec![("one".to_string(), 2.0), ("two".to_string(), 4.0),])
+            Ok(vec![("one".to_string(), 1.0), ("two".to_string(), 2.0)])
         );
-
-        // zinterstore_with_weights with MAX aggregation
-        assert_eq!(
-            con.zinterstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Max)
-            ),
-            Ok(2)
-        );
-
+        assert_eq!(con.zinterstore("out", &["zset1", "zset2"], max()), Ok(2));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
-            Ok(vec![("one".to_string(), 3.0), ("two".to_string(), 6.0),])
+            Ok(vec![("one".to_string(), 5.0), ("two".to_string(), 6.0)])
         );
-    }
-
-    #[test]
-    fn test_zunionstore_options() {
-        let ctx = TestContext::new();
-        let mut con = ctx.connection();
-
-        con.zadd_multiple("zset1", &[(1, "one"), (2, "two")])
-            .unwrap();
-        con.zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
-            .unwrap();
-
-        // zunionstore with SUM aggregation (default)
+        // Weights multiply each set's score before aggregating:
+        // one = (1 * 2), (5 * 3); two = (2 * 2), (6 * 3).
         assert_eq!(
-            con.zunionstore(
-                "out",
-                &["zset1", "zset2"],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(3)
+            con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(2)
         );
-
-        // zunionstore with weights
         assert_eq!(
-            con.zunionstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(3)
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![("one".to_string(), 17.0), ("two".to_string(), 22.0)])
+        );
+        assert_eq!(
+            con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], min()),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![("one".to_string(), 2.0), ("two".to_string(), 4.0)])
+        );
+        assert_eq!(
+            con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], max()),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![("one".to_string(), 15.0), ("two".to_string(), 18.0)])
         );
 
+        // ZUNIONSTORE (union = {one, two, three, four}).
+        // three (only in zset2) and four (only in zset1) pass through unchanged.
+        assert_eq!(con.zunionstore("out", &["zset1", "zset2"], sum()), Ok(4));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
             Ok(vec![
-                ("one".to_string(), 5.0),
-                ("three".to_string(), 9.0),
-                ("two".to_string(), 10.0)
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 6.0),
+                ("two".to_string(), 8.0)
             ])
         );
-
-        // zunionstore_with_weights with MIN aggregation
+        assert_eq!(con.zunionstore("out", &["zset1", "zset2"], min()), Ok(4));
         assert_eq!(
-            con.zunionstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Min)
-            ),
-            Ok(3)
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![
+                ("one".to_string(), 1.0),
+                ("two".to_string(), 2.0),
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0)
+            ])
         );
-
+        assert_eq!(con.zunionstore("out", &["zset1", "zset2"], max()), Ok(4));
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 5.0),
+                ("two".to_string(), 6.0)
+            ])
+        );
+        // Weights (zset1 * 2, zset2 * 3): three = 3 * 3 = 9, four = 4 * 2 = 8.
+        assert_eq!(
+            con.zunionstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(4)
+        );
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 17.0),
+                ("two".to_string(), 22.0)
+            ])
+        );
+        assert_eq!(
+            con.zunionstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], min()),
+            Ok(4)
+        );
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
             Ok(vec![
                 ("one".to_string(), 2.0),
                 ("two".to_string(), 4.0),
+                ("four".to_string(), 8.0),
                 ("three".to_string(), 9.0)
             ])
         );
-
-        // zunionstore_with_weights with MAX aggregation
         assert_eq!(
-            con.zunionstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Max)
-            ),
-            Ok(3)
+            con.zunionstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], max()),
+            Ok(4)
         );
-
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
             Ok(vec![
-                ("one".to_string(), 3.0),
-                ("two".to_string(), 6.0),
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 15.0),
+                ("two".to_string(), 18.0)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_zinterstore_zunionstore_count() {
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        let mut con = ctx.connection();
+
+        con.zadd_multiple("s1", &[(1, "foo"), (1, "bar")]).unwrap();
+        con.zadd_multiple("s2", &[(2, "foo"), (2, "bar")]).unwrap();
+        con.zadd_multiple("s3", &[(3, "foo")]).unwrap();
+
+        // With COUNT and no weights, the score is the number of input sets containing the element.
+        // For the intersection, only foo is present and it is in all 3 sets.
+        assert_eq!(
+            con.zinterstore(
+                "t1",
+                &["s1", "s2", "s3"],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(1)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("foo".to_string(), 3.0)])
+        );
+
+        // For the union, foo is in all 3 sets and bar in 2.
+        assert_eq!(
+            con.zunionstore(
+                "t1",
+                &["s1", "s2", "s3"],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("bar".to_string(), 2.0), ("foo".to_string(), 3.0)])
+        );
+
+        // With COUNT and weights, the score is the sum of the weights of the input sets
+        // containing the element, ignoring the original scores.
+        assert_eq!(
+            con.zinterstore_with_weights(
+                "t1",
+                &[("s1", 10), ("s2", 5), ("s3", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(1)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("foo".to_string(), 18.0)])
+        );
+
+        assert_eq!(
+            con.zunionstore_with_weights(
+                "t1",
+                &[("s1", 10), ("s2", 5), ("s3", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("bar".to_string(), 15.0), ("foo".to_string(), 18.0)])
+        );
+    }
+
+    #[test]
+    fn test_zinter_zunion() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        // Shared members (one, two) have different scores in each set so that
+        // SUM, MIN and MAX each produce distinct, obvious results.
+        con.zadd_multiple("zset1", &[(1, "one"), (2, "two"), (4, "four")])
+            .unwrap();
+        con.zadd_multiple("zset2", &[(5, "one"), (6, "two"), (3, "three")])
+            .unwrap();
+
+        let sum = || SortedSetOperationOptions::default();
+        let min = || SortedSetOperationOptions::default().aggregate(Aggregate::Min);
+        let max = || SortedSetOperationOptions::default().aggregate(Aggregate::Max);
+
+        // ZINTER (intersection = {one, two})
+        // The intersection is always {one, two} and one always scores below two so the order is stable across aggregators.
+        assert_eq!(
+            con.zinter(&["zset1", "zset2"], sum()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter(&["zset1", "zset2"], min()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter(&["zset1", "zset2"], max()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        // With scores:
+        assert_eq!(
+            con.zinter_withscores(&["zset1", "zset2"], sum()),
+            Ok(vec![("one".to_string(), 6.0), ("two".to_string(), 8.0)])
+        );
+        assert_eq!(
+            con.zinter_withscores(&["zset1", "zset2"], min()),
+            Ok(vec![("one".to_string(), 1.0), ("two".to_string(), 2.0)])
+        );
+        assert_eq!(
+            con.zinter_withscores(&["zset1", "zset2"], max()),
+            Ok(vec![("one".to_string(), 5.0), ("two".to_string(), 6.0)])
+        );
+        // Weights multiply each set's score before aggregating:
+        // one = (1 * 2) + (5 * 3)
+        // two = (2 * 2) + (6 * 3)
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec![("one".to_string(), 17.0), ("two".to_string(), 22.0)])
+        );
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec![("one".to_string(), 2.0), ("two".to_string(), 4.0)])
+        );
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec![("one".to_string(), 15.0), ("two".to_string(), 18.0)])
+        );
+
+        // ZUNION (union = {one, two, three, four})
+        // Members only (ordered by resulting score, ties broken lexically).
+        assert_eq!(
+            con.zunion(&["zset1", "zset2"], sum()),
+            Ok(vec![
+                "three".to_string(),
+                "four".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion(&["zset1", "zset2"], min()),
+            Ok(vec![
+                "one".to_string(),
+                "two".to_string(),
+                "three".to_string(),
+                "four".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion(&["zset1", "zset2"], max()),
+            Ok(vec![
+                "three".to_string(),
+                "four".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec![
+                "four".to_string(),
+                "three".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec![
+                "one".to_string(),
+                "two".to_string(),
+                "four".to_string(),
+                "three".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec![
+                "four".to_string(),
+                "three".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        // With scores:
+        assert_eq!(
+            con.zunion_withscores(&["zset1", "zset2"], sum()),
+            Ok(vec![
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 6.0),
+                ("two".to_string(), 8.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_withscores(&["zset1", "zset2"], min()),
+            Ok(vec![
+                ("one".to_string(), 1.0),
+                ("two".to_string(), 2.0),
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_withscores(&["zset1", "zset2"], max()),
+            Ok(vec![
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 5.0),
+                ("two".to_string(), 6.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec![
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 17.0),
+                ("two".to_string(), 22.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec![
+                ("one".to_string(), 2.0),
+                ("two".to_string(), 4.0),
+                ("four".to_string(), 8.0),
                 ("three".to_string(), 9.0)
             ])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec![
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 15.0),
+                ("two".to_string(), 18.0)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_zinter_zunion_count() {
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        let mut con = ctx.connection();
+
+        con.zadd_multiple("s1", &[(1, "foo"), (1, "bar")]).unwrap();
+        con.zadd_multiple("s2", &[(2, "foo"), (2, "bar")]).unwrap();
+        con.zadd_multiple("s3", &[(3, "foo")]).unwrap();
+
+        let count = || SortedSetOperationOptions::default().aggregate(Aggregate::Count);
+
+        // COUNT with no weights = number of input sets containing the element.
+        assert_eq!(
+            con.zinter(&["s1", "s2", "s3"], count()),
+            Ok(vec!["foo".to_string()])
+        );
+        assert_eq!(
+            con.zunion(&["s1", "s2", "s3"], count()),
+            Ok(vec!["bar".to_string(), "foo".to_string()])
+        );
+        // With scores.
+        assert_eq!(
+            con.zinter_withscores(&["s1", "s2", "s3"], count()),
+            Ok(vec![("foo".to_string(), 3.0)])
+        );
+        assert_eq!(
+            con.zunion_withscores(&["s1", "s2", "s3"], count()),
+            Ok(vec![("bar".to_string(), 2.0), ("foo".to_string(), 3.0)])
+        );
+
+        // COUNT with weights = sum of weights of the sets containing the element.
+        assert_eq!(
+            con.zinter_with_weights(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec!["foo".to_string()])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec!["bar".to_string(), "foo".to_string()])
+        );
+        // With scores.
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec![("foo".to_string(), 18.0)])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec![("bar".to_string(), 15.0), ("foo".to_string(), 18.0)])
         );
     }
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -12,12 +12,14 @@ mod basic {
     use rand::{RngExt, rng};
 
     use redis::{
-        Client, Connection, ConnectionInfo, ConnectionLike, ControlFlow, CopyOptions, ErrorKind,
-        ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck, HashFieldExpirationOptions,
+        Aggregate, Client, Connection, ConnectionInfo, ConnectionLike, ControlFlow, CopyOptions,
+        ErrorKind, ExistenceCheck, ExpireOption, Expiry, FieldExistenceCheck,
+        HashFieldExpirationOptions,
         IntegerReplyOrNoOp::{ExistsButNotRelevant, IntegerReply},
         MSetOptions, ProtocolVersion, PubSubCommands, PushInfo, PushKind, RedisConnectionInfo,
-        RedisResult, Role, ScanOptions, SetExpiry, SetOptions, SortedSetAddOptions, ToRedisArgs,
-        TypedCommands, UpdateCheck, Value, ValueComparison, ValueType, cmd,
+        RedisResult, Role, ScanOptions, SetExpiry, SetOptions, SortedSetAddOptions,
+        SortedSetOperationOptions, ToRedisArgs, TypedCommands, UpdateCheck, Value, ValueComparison,
+        ValueType, cmd,
     };
     use redis::{RedisError, ServerErrorKind};
     use redis::{calculate_value_digest, is_valid_16_bytes_hex_digest};
@@ -2330,7 +2332,7 @@ mod basic {
     }
 
     #[test]
-    fn test_zinterstore_weights() {
+    fn test_zinterstore_options() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
@@ -2339,9 +2341,23 @@ mod basic {
         con.zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
             .unwrap();
 
-        // zinterstore_weights
+        // zinterstore with SUM aggregation (default)
         assert_eq!(
-            con.zinterstore_weights("out", &[("zset1", 2), ("zset2", 3)]),
+            con.zinterstore(
+                "out",
+                &["zset1", "zset2"],
+                SortedSetOperationOptions::default()
+            ),
+            Ok(2)
+        );
+
+        // zinterstore with weights
+        assert_eq!(
+            con.zinterstore_with_weights(
+                "out",
+                &[("zset1", 2), ("zset2", 3)],
+                SortedSetOperationOptions::default()
+            ),
             Ok(2)
         );
 
@@ -2350,9 +2366,13 @@ mod basic {
             Ok(vec![("one".to_string(), 5.0), ("two".to_string(), 10.0)])
         );
 
-        // zinterstore_min_weights
+        // zinterstore_with_weights with MIN aggregation
         assert_eq!(
-            con.zinterstore_min_weights("out", &[("zset1", 2), ("zset2", 3)]),
+            con.zinterstore_with_weights(
+                "out",
+                &[("zset1", 2), ("zset2", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Min)
+            ),
             Ok(2)
         );
 
@@ -2361,9 +2381,13 @@ mod basic {
             Ok(vec![("one".to_string(), 2.0), ("two".to_string(), 4.0),])
         );
 
-        // zinterstore_max_weights
+        // zinterstore_with_weights with MAX aggregation
         assert_eq!(
-            con.zinterstore_max_weights("out", &[("zset1", 2), ("zset2", 3)]),
+            con.zinterstore_with_weights(
+                "out",
+                &[("zset1", 2), ("zset2", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Max)
+            ),
             Ok(2)
         );
 
@@ -2374,7 +2398,7 @@ mod basic {
     }
 
     #[test]
-    fn test_zunionstore_weights() {
+    fn test_zunionstore_options() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
@@ -2383,9 +2407,23 @@ mod basic {
         con.zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
             .unwrap();
 
-        // zunionstore_weights
+        // zunionstore with SUM aggregation (default)
         assert_eq!(
-            con.zunionstore_weights("out", &[("zset1", 2), ("zset2", 3)]),
+            con.zunionstore(
+                "out",
+                &["zset1", "zset2"],
+                SortedSetOperationOptions::default()
+            ),
+            Ok(3)
+        );
+
+        // zunionstore with weights
+        assert_eq!(
+            con.zunionstore_with_weights(
+                "out",
+                &[("zset1", 2), ("zset2", 3)],
+                SortedSetOperationOptions::default()
+            ),
             Ok(3)
         );
 
@@ -2397,19 +2435,14 @@ mod basic {
                 ("two".to_string(), 10.0)
             ])
         );
-        // test converting to double
-        assert_eq!(
-            con.zrange_withscores("out", 0, -1),
-            Ok(vec![
-                ("one".to_string(), 5.0),
-                ("three".to_string(), 9.0),
-                ("two".to_string(), 10.0)
-            ])
-        );
 
-        // zunionstore_min_weights
+        // zunionstore_with_weights with MIN aggregation
         assert_eq!(
-            con.zunionstore_min_weights("out", &[("zset1", 2), ("zset2", 3)]),
+            con.zunionstore_with_weights(
+                "out",
+                &[("zset1", 2), ("zset2", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Min)
+            ),
             Ok(3)
         );
 
@@ -2422,9 +2455,13 @@ mod basic {
             ])
         );
 
-        // zunionstore_max_weights
+        // zunionstore_with_weights with MAX aggregation
         assert_eq!(
-            con.zunionstore_max_weights("out", &[("zset1", 2), ("zset2", 3)]),
+            con.zunionstore_with_weights(
+                "out",
+                &[("zset1", 2), ("zset2", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Max)
+            ),
             Ok(3)
         );
 

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -93,7 +93,7 @@ async fn test_cache_basic(test_with_optin: bool) {
 }
 
 #[async_test]
-async fn cache_mget() {
+async fn test_cache_mget() {
     let ctx = TestContext::new();
     if !ctx.protocol.supports_resp3() {
         return;
@@ -149,7 +149,7 @@ async fn cache_mget() {
 
 #[cfg(feature = "json")]
 #[async_test]
-async fn module_cache_json_get_mget() {
+async fn test_module_json_cache_get_mget() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     if !ctx.protocol.supports_resp3() {
         return;
@@ -219,7 +219,7 @@ async fn module_cache_json_get_mget() {
 
 #[cfg(feature = "json")]
 #[async_test]
-async fn module_cache_json_get_mget_different_paths() {
+async fn test_module_json_cache_get_mget_different_paths() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     if !ctx.protocol.supports_resp3() {
         return;
@@ -332,7 +332,7 @@ async fn module_cache_json_get_mget_different_paths() {
 }
 
 #[async_test]
-async fn cache_is_not_target_type_dependent() {
+async fn test_cache_is_not_target_type_dependent() {
     let ctx = TestContext::new();
     if !ctx.protocol.supports_resp3() {
         return;
@@ -398,7 +398,7 @@ async fn test_cache_with_pipeline(atomic: bool) {
 }
 
 #[async_test]
-async fn cache_basic_partial_opt_in() {
+async fn test_cache_basic_partial_opt_in() {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
     let ctx = TestContext::new();
     if !ctx.protocol.supports_resp3() {
@@ -619,14 +619,17 @@ async fn test_connection_manager_maintains_statistics_after_crashes(test_with_op
     assert_hit!(&manager, 1);
     assert_miss!(&manager, 1);
 
+    // Store the server's address and kill the server
     let addr = ctx.server.client_addr().clone();
     drop(ctx);
 
+    // With the server gone, commands should fail
     let result: Result<redis::Value, RedisError> =
         manager.send_packed_command(&redis::cmd("PING")).await;
     assert!(result.unwrap_err().is_unrecoverable_error());
 
-    let _server = redis_test::server::RedisServer::new_with_addr_and_modules(addr, &[], false);
+    // Start a new server, re-using the previous address
+    let _ctx = TestContext::new_with_addr(addr);
 
     loop {
         if manager.send_packed_command(&get).await.is_ok() {
@@ -642,7 +645,7 @@ async fn test_connection_manager_maintains_statistics_after_crashes(test_with_op
 
 #[cfg(feature = "cluster-async")]
 #[async_test]
-async fn cache_async_cluster_reconnect_all_nodes() {
+async fn test_cache_async_cluster_reconnect_all_nodes() {
     let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
         builder.cache_config(CacheConfig::default())
     });
@@ -705,7 +708,7 @@ async fn cache_async_cluster_reconnect_all_nodes() {
 
 #[cfg(feature = "cluster-async")]
 #[async_test]
-async fn cache_async_cluster_mget() {
+async fn test_cache_async_cluster_mget() {
     let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
         builder.cache_config(CacheConfig::default())
     });

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -39,13 +39,6 @@ mod cluster_async {
 
     use crate::support::*;
 
-    fn broken_pipe_error() -> RedisError {
-        RedisError::from(std::io::Error::new(
-            std::io::ErrorKind::BrokenPipe,
-            "mock-io-error",
-        ))
-    }
-
     async fn smoke_test_connection(mut connection: impl redis::aio::ConnectionLike) {
         cmd("SET")
             .arg("test")
@@ -63,7 +56,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_cmd() {
+    async fn test_async_cluster_basic_cmd() {
         let cluster = TestClusterContext::new();
 
         let connection = cluster.async_connection().await;
@@ -124,7 +117,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn no_response_skips_response_even_on_error() {
+    async fn test_no_response_skips_response_even_on_error() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -154,7 +147,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn reconnect_only_the_disconnected_node_leave_other_connections_intact() {
+    async fn test_reconnect_only_the_disconnected_node_leave_other_connections_intact() {
         // we remove retries in order to know that a request will fail immediately when discovering that a connection disconnected, instead of reconnecting and succeeding
         let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(0));
 
@@ -203,7 +196,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_eval() {
+    async fn test_async_cluster_basic_eval() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -219,7 +212,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_script() {
+    async fn test_async_cluster_basic_script() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -235,7 +228,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_route_flush_to_specific_node() {
+    async fn test_async_cluster_route_flush_to_specific_node() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -264,7 +257,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_route_flush_to_node_by_address() {
+    async fn test_async_cluster_route_flush_to_node_by_address() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -300,7 +293,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_route_info_to_nodes() {
+    async fn test_async_cluster_route_info_to_nodes() {
         let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
             num_nodes: 6,
             num_replicas: 1,
@@ -378,7 +371,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn cluster_resp3() {
+    async fn test_cluster_resp3() {
         if !use_protocol().supports_resp3() {
             return;
         }
@@ -395,7 +388,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_pipe() {
+    async fn test_async_cluster_basic_pipe() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -447,7 +440,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_multi_shard_commands() {
+    async fn test_async_cluster_multi_shard_commands() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -462,7 +455,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_can_run_a_transaction() {
+    async fn test_async_cluster_can_run_a_transaction() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -480,7 +473,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls")]
     #[async_test]
-    async fn async_cluster_default_reject_invalid_hostnames() {
+    async fn test_async_cluster_default_reject_invalid_hostnames() {
         use redis_test::cluster::ClusterType;
 
         if ClusterType::get_intended() != ClusterType::TcpTls {
@@ -499,7 +492,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls-insecure")]
     #[async_test]
-    async fn async_cluster_danger_accept_invalid_hostnames() {
+    async fn test_async_cluster_danger_accept_invalid_hostnames() {
         use redis_test::cluster::ClusterType;
 
         if ClusterType::get_intended() != ClusterType::TcpTls {
@@ -521,7 +514,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_failover() {
+    async fn test_async_cluster_basic_failover() {
         test_failover(
                 &TestClusterContext::new_with_config(
                     RedisClusterConfiguration::single_replica_config(),
@@ -697,7 +690,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_error_in_inner_connection() {
+    async fn test_async_cluster_error_in_inner_connection() {
         let cluster = TestClusterContext::new();
 
         let mut con = cluster.async_generic_connection::<ErrorConnection>().await;
@@ -2050,7 +2043,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_with_username_and_password() {
+    async fn test_async_cluster_with_username_and_password() {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder
                 .username(RedisCluster::username())
@@ -2076,7 +2069,7 @@ mod cluster_async {
 
     #[test]
     fn test_async_cluster_io_error() {
-        let name = "node";
+        let name = "test_async_cluster_io_error";
         let completed = Arc::new(AtomicI32::new(0));
         let MockEnv {
             runtime,
@@ -2109,6 +2102,199 @@ mod cluster_async {
                 .query_async::<Option<i32>>(&mut connection),
         );
 
+        assert_eq!(value, Ok(Some(123)));
+    }
+
+    #[test]
+    fn test_async_cluster_io_error_without_fallback_redirects() {
+        let name = "test_async_cluster_io_error_without_fallback_redirects";
+        let moved_served = Arc::new(AtomicBool::new(false));
+        let moved_served_clone = moved_served.clone();
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
+            name,
+            {
+                let dead = Arc::new(AtomicBool::new(false));
+                move |cmd: &[u8], port| match port {
+                    6379 => {
+                        if dead.load(Ordering::SeqCst) {
+                            return Err(Err(broken_pipe_error()));
+                        }
+                        respond_startup_two_nodes(name, cmd)?;
+                        dead.store(true, Ordering::SeqCst);
+                        Err(Err(broken_pipe_error()))
+                    }
+                    6380 => {
+                        respond_startup_two_nodes(name, cmd)?;
+                        moved_served_clone.store(true, Ordering::SeqCst);
+                        Err(parse_redis_value(
+                            format!("-MOVED 123 {name}:6379\r\n").as_bytes(),
+                        ))
+                    }
+                    _ => panic!("unexpected port {port}"),
+                }
+            },
+        );
+
+        let result = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<i32>>(&mut connection),
+        );
+
+        assert!(
+            moved_served.load(Ordering::SeqCst),
+            "with no in-shard fallback the request should fall through to another shard's connection and receive a MOVED",
+        );
+        assert_eq!(
+            result.unwrap_err().kind(),
+            ErrorKind::Io,
+            "following the MOVED back to the dead shard owner should surface its io error",
+        );
+    }
+
+    #[test]
+    fn test_async_cluster_io_error_recovers_via_repair() {
+        let name = "test_async_cluster_io_error_recovers_via_repair";
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(0),
+            name,
+            {
+                let completed = Arc::new(AtomicI32::new(0));
+                move |cmd: &[u8], port| {
+                    respond_startup_two_nodes(name, cmd)?;
+                    // 6379 and 6380 are the two primaries.
+                    // 6379 fails the first data command, then recovers.
+                    match port {
+                        6379 => match completed.fetch_add(1, Ordering::SeqCst) {
+                            0 => Err(Err(broken_pipe_error())),
+                            _ => Err(Ok(redis_value!("123"))),
+                        },
+                        6380 => panic!("Node should not be called"),
+                        _ => panic!("unexpected port {port}"),
+                    }
+                }
+            },
+        );
+
+        let first = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<i32>>(&mut connection),
+        );
+        assert_eq!(
+            first.unwrap_err().kind(),
+            ErrorKind::Io,
+            "first call should surface the underlying connection reset",
+        );
+
+        let second = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<i32>>(&mut connection),
+        );
+        assert_eq!(second, Ok(Some(123)));
+    }
+
+    #[test]
+    fn test_async_cluster_reconnect_does_not_stall_healthy_shard() {
+        let name = "test_async_cluster_reconnect_does_not_stall_healthy_shard";
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(0),
+            name,
+            move |cmd: &[u8], port| {
+                respond_startup_two_nodes(name, cmd)?;
+                // 6379 and 6380 are the two primaries.
+                // "test" key goes to 6379, which is permanently down after the handshake.
+                // "foo" key goes to 6380.
+                match port {
+                    6379 => Err(Err(broken_pipe_error())),
+                    6380 => Err(Ok(redis_value!("123"))),
+                    _ => panic!("unexpected port {port}"),
+                }
+            },
+        );
+
+        let downed = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<i32>>(&mut connection),
+        );
+        assert_eq!(downed.unwrap_err().kind(), ErrorKind::Io);
+
+        let healthy = runtime.block_on(
+            cmd("GET")
+                .arg("foo")
+                .query_async::<Option<i32>>(&mut connection)
+                .timeout(futures_time::time::Duration::from_secs(5)),
+        );
+        assert_eq!(
+            healthy.expect("healthy shard stalled behind the dead shard's reconnect"),
+            Ok(Some(123)),
+        );
+    }
+
+    #[test]
+    fn test_async_cluster_read_routes_around_dead_replica() {
+        let name = "test_async_cluster_read_routes_around_dead_replica";
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(1)
+                .read_routing_strategy(RandomReplicaStrategy),
+            name,
+            {
+                // There are two shards: [6379, 6380] and [6381, 6382].
+                // The primary (6379) is always healthy.
+                // The replica (6380) is dead after the initial handshake.
+                let dead = Arc::new(AtomicBool::new(false));
+                move |cmd: &[u8], port| match port {
+                    6379 => {
+                        respond_startup_with_replica(name, cmd)?;
+                        Err(Ok(redis_value!("123")))
+                    }
+                    6380 => {
+                        if dead.load(Ordering::SeqCst) {
+                            return Err(Err(broken_pipe_error()));
+                        }
+                        respond_startup_with_replica(name, cmd)?;
+                        dead.store(true, Ordering::SeqCst);
+                        Err(Err(broken_pipe_error()))
+                    }
+                    // No data commands should be routed to the second shard.
+                    // Initial handshake is okay.
+                    _ => {
+                        respond_startup_with_replica(name, cmd)?;
+                        panic!("Node {port} should not be called");
+                    }
+                }
+            },
+        );
+
+        let value = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<i32>>(&mut connection),
+        );
         assert_eq!(value, Ok(Some(123)));
     }
 
@@ -2183,7 +2369,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_handle_complete_server_disconnect_without_panicking() {
+    async fn test_async_cluster_handle_complete_server_disconnect_without_panicking() {
         let cluster =
             TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(2));
 
@@ -2207,7 +2393,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_reconnect_after_complete_server_disconnect() {
+    async fn test_async_cluster_reconnect_after_complete_server_disconnect() {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder.retries(2)
         });
@@ -2243,7 +2429,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_reconnect_after_complete_server_disconnect_route_to_many() {
+    async fn test_async_cluster_reconnect_after_complete_server_disconnect_route_to_many() {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder.retries(3)
         });
@@ -2343,7 +2529,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn kill_connection_on_drop_even_when_blocking() {
+    async fn test_kill_connection_on_drop_even_when_blocking() {
         let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(3));
 
         async fn count_ids(conn: &mut impl redis::aio::ConnectionLike) -> RedisResult<usize> {
@@ -2447,7 +2633,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_connect_lazily() {
+    async fn test_async_cluster_connect_lazily() {
         let cluster = TestClusterContext::new();
 
         let connection = cluster
@@ -2457,7 +2643,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn fail_on_empty_command() {
+    async fn test_fail_on_empty_command() {
         let cluster = TestClusterContext::new();
         let mut connection = cluster.async_connection().await;
 
@@ -2574,7 +2760,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_subscription() {
+        async fn test_pub_sub_subscription() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
@@ -2592,7 +2778,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_subscription_with_config() {
+        async fn test_pub_sub_subscription_with_config() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder.use_protocol(ProtocolVersion::RESP3)
@@ -2611,7 +2797,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_shardnumsub() {
+        async fn test_pub_sub_shardnumsub() {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder.use_protocol(ProtocolVersion::RESP3)
             });
@@ -2630,7 +2816,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_unsubscription() {
+        async fn test_pub_sub_unsubscription() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
@@ -2720,7 +2906,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn connection_is_still_usable_if_pubsub_receiver_is_dropped() {
+        async fn test_connection_is_still_usable_if_pubsub_receiver_is_dropped() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
@@ -2745,7 +2931,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn multiple_subscribes_and_unsubscribes_work() {
+        async fn test_multiple_subscribes_and_unsubscribes_work() {
             // In this test we subscribe on all subscription variations to 3 channels in a single call, then unsubscribe from 2 channels.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
@@ -2868,7 +3054,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_reconnect_after_disconnect() {
+        async fn test_pub_sub_reconnect_after_disconnect() {
             // in this test we will subscribe to channels, then restart the server, and check that the connection
             // doesn't send disconnect message, but instead resubscribes automatically.
 
@@ -2955,7 +3141,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_should_not_reconnect_if_subscription_failed() {
+        async fn test_pub_sub_should_not_reconnect_if_subscription_failed() {
             // in this test we will try to subscribe to a disconnected cluster, fail, and check that once the connection reconnects it won't try and resubscribe.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
@@ -3031,7 +3217,7 @@ mod cluster_async {
         use super::*;
 
         #[async_test]
-        async fn async_cluster_basic_cmd_with_mtls() {
+        async fn test_async_cluster_basic_cmd_with_mtls() {
             let cluster = TestClusterContext::new_with_mtls();
 
             let client = create_cluster_client_from_cluster(&cluster, true).unwrap();
@@ -3052,7 +3238,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn async_cluster_should_not_connect_without_mtls_enabled() {
+        async fn test_async_cluster_should_not_connect_without_mtls_enabled() {
             let cluster = TestClusterContext::new_with_mtls();
 
             let client = create_cluster_client_from_cluster(&cluster, false).unwrap();
@@ -3110,7 +3296,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn simple_case_success() {
+        async fn test_simple_case_success() {
             let cluster = TestClusterContext::new();
             let mut con = cluster.async_connection().await;
 
@@ -3136,7 +3322,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_watch() {
+        async fn test_transaction_should_retry_on_watch() {
             let cluster = TestClusterContext::new();
             let con1 = cluster.async_connection().await;
             let mut con2 = cluster.async_connection().await;
@@ -3185,7 +3371,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_none_from_closure() {
+        async fn test_transaction_should_retry_on_none_from_closure() {
             let cluster = TestClusterContext::new();
             let con = cluster.async_connection().await;
 
@@ -3215,7 +3401,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn transaction_abort_if_internal_function_returns_error() {
+        async fn test_transaction_abort_if_internal_function_returns_error() {
             let cluster = TestClusterContext::new();
             let con = cluster.async_connection().await;
             let attempts = Arc::new(AtomicUsize::new(0));

--- a/redis/tests/test_geospatial.rs
+++ b/redis/tests/test_geospatial.rs
@@ -146,12 +146,16 @@ fn test_georadius() {
     assert_eq!(result[0].name.as_str(), "Catania");
     assert_eq!(result[0].coord, None);
     assert_eq!(result[0].dist, None);
+    assert_eq!(result[0].hash, None);
 
     assert_eq!(result[1].name.as_str(), "Palermo");
     assert_eq!(result[1].coord, None);
     assert_eq!(result[1].dist, None);
+    assert_eq!(result[1].hash, None);
 
     // Get data with multiple fields
+
+    // With distance
     let result = geo_radius(RadiusOptions::default().with_dist().order(RadiusOrder::Asc));
 
     assert_eq!(result.len(), 2);
@@ -159,11 +163,14 @@ fn test_georadius() {
     assert_eq!(result[0].name.as_str(), "Catania");
     assert_eq!(result[0].coord, None);
     assert_approx_eq!(result[0].dist.unwrap(), 56.4413, 0.001);
+    assert_eq!(result[0].hash, None);
 
     assert_eq!(result[1].name.as_str(), "Palermo");
     assert_eq!(result[1].coord, None);
     assert_approx_eq!(result[1].dist.unwrap(), 190.4424, 0.001);
+    assert_eq!(result[1].hash, None);
 
+    // With coordinates
     let result = geo_radius(
         RadiusOptions::default()
             .with_coord()
@@ -177,6 +184,22 @@ fn test_georadius() {
     assert_approx_eq!(result[0].coord.as_ref().unwrap().longitude, 13.361_389);
     assert_approx_eq!(result[0].coord.as_ref().unwrap().latitude, 38.115_556);
     assert_eq!(result[0].dist, None);
+    assert_eq!(result[0].hash, None);
+
+    // With hashes
+    let result = geo_radius(RadiusOptions::default().with_hash().order(RadiusOrder::Asc));
+
+    assert_eq!(result.len(), 2);
+
+    assert_eq!(result[0].name.as_str(), "Catania");
+    assert_eq!(result[0].coord, None);
+    assert_eq!(result[0].dist, None);
+    assert_eq!(result[0].hash, Some(3479447370796909));
+
+    assert_eq!(result[1].name.as_str(), "Palermo");
+    assert_eq!(result[1].coord, None);
+    assert_eq!(result[1].dist, None);
+    assert_eq!(result[1].hash, Some(3479099956230698));
 }
 
 #[test]
@@ -194,4 +217,34 @@ fn test_georadius_by_member() {
     let names: Vec<_> = result.iter().map(|c| c.name.as_str()).collect();
 
     assert_eq!(names, vec!["Agrigento", "Palermo"]);
+
+    // Simple request, with all available data
+    let opts = RadiusOptions::default()
+        .with_dist()
+        .with_coord()
+        .with_hash()
+        .order(RadiusOrder::Asc);
+    let result = con
+        .geo_radius_by_member("my_gis", AGRIGENTO.2, 100.0, Unit::Kilometers, opts)
+        .unwrap();
+
+    assert_eq!(result[0].name.as_str(), "Agrigento");
+    assert_approx_eq!(
+        result[0].coord.as_ref().unwrap().longitude,
+        13.58333,
+        0.0001
+    );
+    assert_approx_eq!(result[0].coord.as_ref().unwrap().latitude, 37.31667, 0.0001);
+    assert_approx_eq!(result[0].dist.unwrap(), 0.0, 0.001);
+    assert_eq!(result[0].hash, Some(3479030013248308));
+
+    assert_eq!(result[1].name.as_str(), "Palermo");
+    assert_approx_eq!(
+        result[1].coord.as_ref().unwrap().longitude,
+        13.36139,
+        0.0001
+    );
+    assert_approx_eq!(result[1].coord.as_ref().unwrap().latitude, 38.11556, 0.0001);
+    assert_approx_eq!(result[1].dist.unwrap(), 90.9778, 0.001);
+    assert_eq!(result[1].hash, Some(3479099956230698));
 }

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -679,7 +679,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_connect_to_random_replica_async() {
+    async fn test_sentinel_connect_to_random_replica_async() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let node_conn_info = context.sentinel_node_connection_info();
@@ -708,7 +708,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_connect_to_multiple_replicas_async() {
+    async fn test_sentinel_connect_to_multiple_replicas_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut cluster = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -747,7 +747,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_server_down_async() {
+    async fn test_sentinel_server_down_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -792,7 +792,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_redis_client_async() {
+    async fn test_sentinel_redis_client_async() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -832,7 +832,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async() {
+    async fn test_sentinel_client_async() {
         let master_name = "master1";
         let context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -867,7 +867,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_not_sentinel_error() {
+    async fn test_sentinel_client_async_not_sentinel_error() {
         let master_name = "master1";
 
         let mut context = TestSentinelContext::new(2, 3, 3);
@@ -898,7 +898,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_io_error() {
+    async fn test_sentinel_client_async_io_error() {
         let master_name = "master1";
 
         let mut master_client = SentinelClient::build(
@@ -915,7 +915,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_with_connection_timeout() {
+    async fn test_sentinel_client_async_with_connection_timeout() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -964,7 +964,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_with_response_timeout() {
+    async fn test_sentinel_client_async_with_response_timeout() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -1012,7 +1012,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_with_timeouts() {
+    async fn test_sentinel_client_async_with_timeouts() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -1060,7 +1060,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_success_async() {
+    async fn test_get_replica_clients_success_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -1075,7 +1075,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_invalid_master_name_async() {
+    async fn test_get_replica_clients_invalid_master_name_async() {
         let mut context = TestSentinelContext::new(2, 2, 3);
         let node_conn_info = context.sentinel_node_connection_info();
         let sentinel = context.sentinel_mut();
@@ -1095,7 +1095,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_report_correct_master_async() {
+    async fn test_get_replica_clients_report_correct_master_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -1121,7 +1121,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_with_one_replica_down_async() {
+    async fn test_get_replica_clients_with_one_replica_down_async() {
         let number_of_replicas = 3;
         let master_name = "master0";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);

--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -3,11 +3,15 @@ use quote::quote;
 
 #[proc_macro_attribute]
 pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
-    let item = syn::parse_macro_input!(input as syn::ItemFn);
+    let mut item = syn::parse_macro_input!(input as syn::ItemFn);
 
+    let test_function_name = item.sig.ident.clone();
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
     let function_name = item.sig.ident.clone();
-    let test_function_name =
-        syn::Ident::new(&format!("test_{function_name}"), function_name.span());
 
     let final_code = if item.sig.inputs.len() == 1 {
         let Some(syn::FnArg::Typed(pat_type)) = item.sig.inputs.last() else {
@@ -16,7 +20,7 @@ pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
                 .into();
         };
         // Verify the argument is a boolean
-        let is_bool = matches!(&*pat_type.ty, syn::Type::Path(type_path) 
+        let is_bool = matches!(&*pat_type.ty, syn::Type::Path(type_path)
                 if type_path.path.is_ident("bool"));
         let is_connection = matches!(&*pat_type.ty, syn::Type::ImplTrait(impl_trait)
         if impl_trait.bounds.iter().any(|bound| {
@@ -25,39 +29,34 @@ pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
         }));
 
         if is_connection {
-            let test_multiplexed_connection_function_name = syn::Ident::new(
-                &format!("test_multiplexed_connection_{function_name}"),
-                function_name.span(),
-            );
-            let test_connection_manager_function_name = syn::Ident::new(
-                &format!("test_connection_manager_{function_name}"),
-                function_name.span(),
-            );
-
             quote! {
-                #item
+                mod #test_function_name {
+                    use super::*;
+                    #item
 
-                #[rstest::rstest]
-                #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
-                #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
-                fn #test_multiplexed_connection_function_name (#[case]runtime: support::RuntimeType) {
-                    let ctx = TestContext::new();
-                    support::block_on_all(async move {
-                        let conn = ctx.async_connection().await.unwrap();
-                        #function_name (conn).await
-                    }, runtime);
-                }
+                    #[rstest::rstest]
+                    #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
+                    #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
+                    fn multiplexed_connection (#[case]runtime: support::RuntimeType) {
+                        let ctx = TestContext::new();
+                        support::block_on_all(async move {
+                            let conn = ctx.async_connection().await.unwrap();
+                            #function_name (conn).await
+                        }, runtime);
+                    }
 
-                #[rstest::rstest]
-                #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
-                #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
-                #[cfg(feature = "connection-manager")]
-                fn #test_connection_manager_function_name (#[case]runtime: support::RuntimeType) {
-                    let ctx = TestContext::new();
-                    support::block_on_all(async move {
-                        let conn = ctx.client.get_connection_manager().await.unwrap();
-                        #function_name (conn).await
-                    }, runtime);
+                    #[rstest::rstest]
+                    #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
+                    #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
+                    #[cfg(feature = "connection-manager")]
+                    fn connection_manager (#[case]runtime: support::RuntimeType) {
+                        let ctx = TestContext::new();
+                        support::block_on_all(async move {
+                            let conn = ctx.client.get_connection_manager().await.unwrap();
+                            #function_name (conn).await
+                        }, runtime);
+                    }
+
                 }
             }
         } else if is_bool {

--- a/version2.md
+++ b/version2.md
@@ -1,0 +1,68 @@
+# Announcing redis-rs & redis-test 2.0.0
+
+With version 1.0.0 behind us, version 2.0.0 begins a new major series, with redis-test tracking it with the same version.
+
+This document highlights the breaking changes in version 2.0.0. For a complete list of changes, see CHANGELOG.md. We appreciate feedback and bug reports — please open an issue for anything you encounter during migration. In order to get the newest version, please specify in your Cargo.toml file
+
+```toml
+redis = "2"
+```
+
+## Breaking Changes
+
+### `cmd_iter` yields `CmdRef` instead of `&Cmd` (Breaking Change)
+
+**Most users can upgrade to 2.0.0 with no code changes.** The flattening is an internal representation change; the pipeline builder API (`cmd`, `arg`, `add_command`, `ignore`, `query`, `query_async`, `exec`, …) is unchanged. The only adjustments are needed if you iterate a pipeline's commands or call `with_capacity` directly.
+
+Because a pipeline no longer owns a `Vec<Cmd>`, there is no `&Cmd` to hand out. [`Pipeline::cmd_iter`] and [`ClusterPipeline::cmd_iter`] now yield `CmdRef<'_>`, a lightweight, `Copy` view that borrows directly into the pipeline's shared buffers — iterating a pipeline's commands performs no per-command allocation.
+
+`CmdRef` is intentionally opaque so that the underlying storage can keep evolving. It exposes the read-only accessors you previously reached for on `&Cmd`, including `args_iter()`, `arg_idx()`, `data()`, `cursor()`, `is_no_response()`, and `get_packed_command()`. If you genuinely need an owned `Cmd`, call `to_cmd()`.
+
+**Migration:** Update code that iterates a pipeline's commands. Most call sites only need to drop a borrow or call an accessor:
+
+```rust
+// Before:
+for cmd in pipe.cmd_iter() {
+    let name = cmd.arg_idx(0);
+    // cmd: &Cmd
+}
+
+// After:
+for cmd in pipe.cmd_iter() {
+    let name = cmd.arg_idx(0);
+    // cmd: CmdRef<'_> — same read accessors, Copy
+}
+```
+
+If you stored or passed the `&Cmd` onward and need an owned value:
+
+```rust
+// Before:
+let owned: Vec<Cmd> = pipe.cmd_iter().cloned().collect();
+
+// After:
+let owned: Vec<Cmd> = pipe.cmd_iter().map(|cmd| cmd.to_cmd()).collect();
+```
+
+### `Pipeline::with_capacity` is replaced by `reserve_for_*` methods (Breaking Change)
+
+[`Pipeline::with_capacity`] and [`ClusterPipeline::with_capacity`] have been removed. A flattened pipeline stores its commands across three buffers (commands, arguments, and argument bytes), and a single capacity number no longer maps cleanly onto them. Rather than force you to estimate all three up front, pre-allocation is now opt-in per buffer via chainable methods, so you reserve only the dimensions you actually have a number for:
+
+```rust
+pub fn reserve_for_commands(&mut self, additional: usize) -> &mut Self
+pub fn reserve_for_args(&mut self, additional: usize) -> &mut Self
+pub fn reserve_for_data(&mut self, additional: usize) -> &mut Self // argument bytes
+```
+
+**Migration:** Replace `with_capacity` with the reservations you can estimate:
+
+```rust
+// Before:
+let mut pipe = redis::Pipeline::with_capacity(16); // 16 commands
+
+// After: reserve whichever buffers you have an estimate for
+let mut pipe = redis::pipe();
+pipe.reserve_for_commands(16).reserve_for_args(48);
+```
+
+`Pipeline::new()` and `pipe()` are unchanged.

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,56 @@ redis = "2"
 
 ## Breaking Changes
 
+### `RedisServer::new_with_addr_tls_modules_and_spawner` got removed (Breaking Change)
+
+All callers used the spawner function to adjust the command's arguments, then spawn and unwrap it.
+The spawning was the same across all of them, hence duplicated.
+The unwrapping only differed in thoroughness of the error handling.
+So the common spawning and unwrapping got moved into `RedisServer` to ease its use.
+
+Refining the server's start command is available via `RedisServer::new_with_addr_tls_modules_and_cmd_refiner`.
+
+**Migration:** Switch from `RedisServer::new_with_addr_tls_modules_and_spawner` to `RedisServer::new_with_addr_tls_modules_and_cmd_refiner`.
+
+Typically, replacing `new_with_addr_tls_modules_and_spawner` by `new_with_addr_tls_modules_and_cmd_refiner` and removing the `cmd.spawn().unwrap()` from your spawning function end will be enough.
+The `cmd_refiner` function takes a `RedisStartCommand` as argument (instead of a `Command` before).
+
+This new `RedisStartCommand` also has a `arg()` method, so your spawners probably work out of the box.
+
+```rust
+// Before:
+
+let server = RedisServer::new_with_addr_tls_modules_and_spawner(
+    addr,
+    None,
+    None,
+    false,
+    None,
+    &[], |cmd| {
+        cmd.arg("--foo")
+            .arg("value-foo")
+            .arg("--bar")
+            .arg("value-baz");
+        cmd.spawn().unwrap()
+    }
+);
+
+// After:
+let server = RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
+    addr,
+    None,
+    None,
+    false,
+    None,
+    &[], |cmd| {
+        cmd.arg("--foo")
+            .arg("value-foo")
+            .arg("--bar")
+            .arg("value-baz");
+    }
+);
+```
+
 ### `Generic` typed commands have their `RV` moved from first to last parameter (Breaking Change)
 
 Untyped commands (`Commands`, `AsyncCommands`) have the return value's type (`RV`) as last type parameter, while for typed commands (`TypedCommands`, `AsyncTypedCommands`) it was the first.

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,21 @@ redis = "2"
 
 ## Breaking Changes
 
+### TCP_NODELAY is now enabled by default (Breaking Change)
+
+By default, Nagle's algorithm is now disabled on every TCP connection the crate creates (sync and async, plaintext and TLS). Previously it was left enabled, which serialized writes on a multiplexed connection to one per ACK round-trip under concurrency — measured at 39–68% lower throughput and roughly double the p50 latency on a real network (see [#2195](https://github.com/redis-rs/redis-rs/issues/2195) for the full evidence). Sequential request-response traffic is unaffected, and Redis clients in other ecosystems already ship with TCP_NODELAY enabled.
+
+No API changed, but the wire behavior did: the client now emits more, smaller packets at moderate concurrency. Deployments close to packets-per-second limits (small cloud instances) or on metered/WAN links may prefer the old behavior.
+
+**Migration:** nothing to do for most users — expect lower latency and higher multiplexed throughput. To keep Nagle's algorithm:
+
+```rust
+use redis::{IntoConnectionInfo, io::tcp::TcpSettings};
+
+let info = "redis://127.0.0.1/".into_connection_info()?
+    .set_tcp_settings(TcpSettings::default().set_nodelay(false));
+```
+
 ### `cmd_iter` yields `CmdRef` instead of `&Cmd` (Breaking Change)
 
 **Most users can upgrade to 2.0.0 with no code changes.** The flattening is an internal representation change; the pipeline builder API (`cmd`, `arg`, `add_command`, `ignore`, `query`, `query_async`, `exec`, …) is unchanged. The only adjustments are needed if you iterate a pipeline's commands or call `with_capacity` directly.

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,24 @@ redis = "2"
 
 ## Breaking Changes
 
+### `Generic` typed commands have their `RV` moved from first to last parameter (Breaking Change)
+
+Untyped commands (`Commands`, `AsyncCommands`) have the return value's type (`RV`) as last type parameter, while for typed commands (`TypedCommands`, `AsyncTypedCommands`) it was the first.
+
+Now both typed and untyped commands have their return value's type as last type parameter.
+
+**Migration:** Move the return type parameter to the last position, if you explicitly gave it.
+
+```rust
+// Before:
+con.rpop::<Vec<String>, _>("foo", NonZeroUsize::new(1));
+//         ^^^ RV as first type parameter
+
+// After:
+con.rpop::<_, Vec<String>>("foo", NonZeroUsize::new(1));
+//            ^^^ RV as last type parameter
+```
+
 ### TCP_NODELAY is now enabled by default (Breaking Change)
 
 By default, Nagle's algorithm is now disabled on every TCP connection the crate creates (sync and async, plaintext and TLS). Previously it was left enabled, which serialized writes on a multiplexed connection to one per ACK round-trip under concurrency — measured at 39–68% lower throughput and roughly double the p50 latency on a real network (see [#2195](https://github.com/redis-rs/redis-rs/issues/2195) for the full evidence). Sequential request-response traffic is unaffected, and Redis clients in other ecosystems already ship with TCP_NODELAY enabled.

--- a/version2.md
+++ b/version2.md
@@ -43,6 +43,43 @@ let info = "redis://127.0.0.1/".into_connection_info()?
     .set_tcp_settings(TcpSettings::default().set_nodelay(false));
 ```
 
+### Removed `zinterstore_*` and `zunionstore_*` commands in favor of `zinterstore`, `zinterstore_with_weights`, `zunionstore`, and `zunionstore_with_weights`
+
+The following commands have been removed:
+
+- `zinterstore_min`, `zinterstore_max`
+- `zinterstore_weights`, `zinterstore_min_weights`, `zinterstore_max_weights`
+- `zunionstore_min`, `zunionstore_max`
+- `zunionstore_weights`, `zunionstore_min_weights`, `zunionstore_max_weights`
+
+Adding more options to these commands would have caused an exponential explosion of variants. Instead, there are now two variants for each command:
+
+- `zinterstore(dstkey, keys, options)` / `zunionstore(dstkey, keys, options)` — keys without weights
+- `zinterstore_with_weights(dstkey, keys_and_weights, options)` / `zunionstore_with_weights(dstkey, keys_and_weights, options)` — keys paired with weights as `&[(key, weight)]`
+
+The `SortedSetOperationOptions` struct carries only the optional `AGGREGATE` modifier and defaults to `SUM`.
+
+**Migration:**
+
+```rust
+use redis::{Commands, SortedSetOperationOptions, Aggregate};
+
+// Before:
+con.zinterstore("out", &["zset1", "zset2"])?;
+con.zinterstore_min("out", &["zset1", "zset2"])?;
+con.zinterstore_weights("out", &[("zset1", 2), ("zset2", 3)])?;
+con.zinterstore_min_weights("out", &[("zset1", 2), ("zset2", 3)])?;
+
+// After:
+con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default())?;
+con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))?;
+con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default())?;
+con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))?;
+```
+
+The same pattern applies to `zunionstore` and `zunionstore_with_weights`.
+
+
 ### `cmd_iter` yields `CmdRef` instead of `&Cmd` (Breaking Change)
 
 **Most users can upgrade to 2.0.0 with no code changes.** The flattening is an internal representation change; the pipeline builder API (`cmd`, `arg`, `add_command`, `ignore`, `query`, `query_async`, `exec`, …) is unchanged. The only adjustments are needed if you iterate a pipeline's commands or call `with_capacity` directly.

--- a/version2.md
+++ b/version2.md
@@ -26,6 +26,8 @@ The `cmd_refiner` function takes a `RedisStartCommand` as argument (instead of a
 
 This new `RedisStartCommand` also has a `arg()` method, so your spawners probably work out of the box.
 
+But it also comes with `arg2()`, and `arg3()`, which takes multiple arguments in a single function, and can help to make things more readable.
+
 ```rust
 // Before:
 
@@ -52,10 +54,8 @@ let server = RedisServer::new_with_addr_tls_modules_and_cmd_refiner(
     false,
     None,
     &[], |cmd| {
-        cmd.arg("--foo")
-            .arg("value-foo")
-            .arg("--bar")
-            .arg("value-baz");
+        cmd.arg2("--foo", "value-foo")
+            .arg2("--bar", "value-baz");
     }
 );
 ```


### PR DESCRIPTION
# Add support for the `COUNT` aggregator to sorted set intersection/union commands

## Summary

Introduce the missing `ZINTER` / `ZUNION` commands.

Add support for the `COUNT` aggregator (new in **Redis 8.8**) to the existing set operation commands (**`ZINTERSTORE` / `ZUNIONSTORE`**)

## Background - what is the COUNT aggregator?

`ZUNIONSTORE` / `ZINTERSTORE` / `ZUNION` / `ZINTER` combine sorted sets and compute each output element's score by aggregating its per-input scores.

Until version 8.8 the aggregator was one of:

| Aggregator | Output score for an element |
|------------|-----------------------------|
| `SUM` (default) | `Σ (score × weight)` over the input sets containing it |
| `MIN` | `min(score × weight)` |
| `MAX` | `max(score × weight)` |

These all operate on the **stored scores**.
A common need is to score an element purely by **how many input sets contain it** (e.g. "for each player, the number of leaderboards they appear on"), ignoring the stored scores entirely.

Redis 8.8 adds `COUNT` for exactly this. It ignores the input scores and sums the **weights** instead (default weight `1`):

| Mode | Output score for an element |
|------|-----------------------------|
| `COUNT` without `WEIGHTS` | number of input sets that contain it |
| `COUNT` with `WEIGHTS` | sum of the weights of the input sets that contain it |

For an **intersection**, the element is by definition in every input set, so the no-weights score equals the number of input keys.

### Example
Input:
```
s1 = { foo: 1, bar: 1 }
s2 = { foo: 2, bar: 2 }
s3 = { foo: 3 }
```
Command and resulting sorted set:
```
ZUNIONSTORE t1 3 s1 s2 s3 AGGREGATE COUNT
  -> bar: 2, foo: 3                      (membership count)

ZINTERSTORE t1 3 s1 s2 s3 AGGREGATE COUNT
  -> foo: 3                              (foo is the only common element)

ZUNIONSTORE t1 3 s1 s2 s3 WEIGHTS 10 5 3 AGGREGATE COUNT
  -> bar: 15, foo: 18                    (Σ weights of containing sets)

ZINTERSTORE t1 3 s1 s2 s3 WEIGHTS 10 5 3 AGGREGATE COUNT
  -> foo: 18
```

Before this command-level support, the only way to get this was the documented workaround: 
Copy each set with all scores rewritten to `1`, then `ZUNIONSTORE` with `SUM`. `COUNT` removes that entirely.

## Testing

| Test | Gating | Covers |
|------|--------|--------|
| `test_zinterstore_zunionstore` | none | `sum`, `min` and `max` aggregators, weighted and uweighted variants |
| `test_zinterstore_zunionstore_count` | 8.8 | the new `COUNT `aggregator for `zinterstore` /`zunionstore` |
| `test_zinter_zunion` | none | `sum`, `min` and `max` aggregators, weighted and unweighted variants, members only and `WITHSCORES` |
| `test_zinter_zunion_count` | 8.8 | the new `COUNT` aggregator for `zinter` / `zunion` |

## Relevant documentation:
ZINTER - https://redis.io/docs/latest/commands/zinter/
ZUNION - https://redis.io/docs/latest/commands/zunion/
ZINTERSTORE - https://redis.io/docs/latest/commands/zinterstore/
ZUNIONSTORE - https://redis.io/docs/latest/commands/zunionstore/